### PR TITLE
Make the report generator extensible

### DIFF
--- a/conf/report-template.html
+++ b/conf/report-template.html
@@ -34,14 +34,10 @@
                 return 1;
             }
 
-            /* post conversion a and b */
-            var A = 0;
-            var B = 0;
-
             var a_parts = a.split(".");
             var b_parts = b.split(".");
 
-            /* One or none of these will be executed */
+            /* One or none of these loops will be executed */
             while (a_parts.length < b_parts.length) {
                 a_parts.push("0");
             }

--- a/conf/report-template.html
+++ b/conf/report-template.html
@@ -69,10 +69,33 @@
     </script>
 
     <script>
+        $.fn.dataTable.ext.order['test-status'] = function ( settings, col ) {
+          return this.api().column( col, {order:'index'} ).nodes().map( function ( td, i ) {
+
+            if (td.className.includes("test-passed")) {
+              return 1;
+            }
+
+            if (td.className.includes("test-failed")) {
+              return 2;
+            }
+
+            return 3;
+          });
+        };
+    </script>
+
+    <script>
         $(document).ready( function () {
-            $('#T_sv-test-report-table').DataTable( {
+            $('#report_table').DataTable( {
                 paging: false,
-                "columnDefs": [ { "type": "sv-id", targets: 0 } ]
+                "columnDefs": [ { "type": "sv-id", targets: 0 } ],
+                "columns": [
+                  null,
+                  {% for tool in report %}
+                  { "orderDataType": "test-status" },
+                  {% endfor %}
+                 ]
             });
         } );
     </script>
@@ -82,11 +105,41 @@
         table.dataTable {
             width: auto;
         }
+
+        .test-failed {
+          background-color: #ff6961;
+        }
+        .test-passed {
+          background-color: #89E894;
+        }
+        .test-na {
+          background-color: #cfcece;
+        }
+
     </style>
   </head>
 
   <body>
-    {{ report_table }}
+    <table id="report_table">
+      <thead>
+        <tr>
+          <th>  </th>
+          {% for tool in report %}
+          <th> {{ tool }} </th>
+          {% endfor %}
+        </tr>
+      </thead>
+        {% for tag, info in database.items() %}
+        <tr>
+          <th> {{ tag }} </th>
+          {% for tool, tooldata in report.items() %}
+          <th class="{{ tooldata[tag] }}">
+          </th>
+          {% endfor %}
+        </tr>
+      {% endfor %}
+    </table>
+
   </body>
 
 </html>

--- a/conf/report-template.html
+++ b/conf/report-template.html
@@ -1,3 +1,6 @@
+{% if False %}
+<!-- vim: set ts=2 sts=2 sw=2 et: -->
+{% endif %}
 <!DOCTYPE html>
 <html>
   <head>
@@ -10,111 +13,111 @@
 
     <!-- custom sorting for the chapter IDs -->
     <script>
-        function isChapterNumber(a) {
-            var parts = a.split(".");
+      function isChapterNumber(a) {
+        var parts = a.split(".");
 
-            for (var i = 0; i < parts.length; i++) {
+        for (var i = 0; i < parts.length; i++) {
 
-                if (isNaN(Number(parts[i]))) {
-                    return false;
-                }
-            }
+        if (isNaN(Number(parts[i]))) {
+           return false;
+         }
+       }
 
-            return true;
-        };
+        return true;
+      };
 
-        function chapterNumberCompare(a, b) {
-            if (!isChapterNumber(a)) {
-                if (!isChapterNumber(b)) {
-                    return ((a < b) ? -1 : ((a > b) ? 1 : 0));
-                } else {
-                    return -1;
-                }
-            } else if (!isChapterNumber(b)) {
-                return 1;
-            }
-
-            var a_parts = a.split(".");
-            var b_parts = b.split(".");
-
-            /* One or none of these loops will be executed */
-            while (a_parts.length < b_parts.length) {
-                a_parts.push("0");
-            }
-
-            while (a_parts.length > b_parts.length) {
-                b_parts.push("0");
-            }
-
-            for (var i = 0; i < a_parts.length; i++) {
-                if (Number(a_parts[i]) == Number(b_parts[i])) {
-                  continue;
-                } else if (Number(a_parts[i]) < Number(b_parts[i])) {
-                    return -1;
-                } else if (Number(a_parts[i]) > Number(b_parts[i])) {
-                  return 1;
-                }
-            }
-
-            return 0;
+      function chapterNumberCompare(a, b) {
+        if (!isChapterNumber(a)) {
+          if (!isChapterNumber(b)) {
+            return ((a < b) ? -1 : ((a > b) ? 1 : 0));
+          } else {
+            return -1;
+          }
+        } else if (!isChapterNumber(b)) {
+          return 1;
         }
 
-        $.fn.dataTable.ext.type.order['sv-id-asc'] = function (a, b) {
-                return chapterNumberCompare(a, b);
-        };
+        var a_parts = a.split(".");
+        var b_parts = b.split(".");
 
-        $.fn.dataTable.ext.type.order['sv-id-desc'] = function (a, b) {
-                return chapterNumberCompare(b, a);
-        };
+        /* One or none of these loops will be executed */
+        while (a_parts.length < b_parts.length) {
+          a_parts.push("0");
+        }
+
+        while (a_parts.length > b_parts.length) {
+          b_parts.push("0");
+        }
+
+        for (var i = 0; i < a_parts.length; i++) {
+          if (Number(a_parts[i]) == Number(b_parts[i])) {
+            continue;
+          } else if (Number(a_parts[i]) < Number(b_parts[i])) {
+            return -1;
+          } else if (Number(a_parts[i]) > Number(b_parts[i])) {
+            return 1;
+          }
+        }
+
+        return 0;
+      }
+
+      $.fn.dataTable.ext.type.order['sv-id-asc'] = function (a, b) {
+        return chapterNumberCompare(a, b);
+      };
+
+      $.fn.dataTable.ext.type.order['sv-id-desc'] = function (a, b) {
+        return chapterNumberCompare(b, a);
+      };
     </script>
 
     <script>
-        $.fn.dataTable.ext.order['test-status'] = function ( settings, col ) {
-          return this.api().column( col, {order:'index'} ).nodes().map( function ( td, i ) {
+      $.fn.dataTable.ext.order['test-status'] = function ( settings, col ) {
+        return this.api().column( col, {order:'index'} ).nodes().map( function ( td, i ) {
 
-            if (td.className.includes("test-passed")) {
-              return 1;
-            }
+          if (td.className.includes("test-passed")) {
+            return 1;
+          }
 
-            if (td.className.includes("test-failed")) {
-              return 2;
-            }
+          if (td.className.includes("test-failed")) {
+            return 2;
+          }
 
-            return 3;
-          });
-        };
+          return 3;
+        });
+      };
     </script>
 
     <script>
-        $(document).ready( function () {
-            $('#report_table').DataTable( {
-                paging: false,
-                "columnDefs": [ { "type": "sv-id", targets: 0 } ],
-                "columns": [
-                  null,
-                  {% for tool in report %}
-                  { "orderDataType": "test-status" },
-                  {% endfor %}
-                 ]
-            });
-        } );
+      $(document).ready( function () {
+        $('#report_table').DataTable( {
+          paging: false,
+          "columnDefs": [ { "type": "sv-id", targets: 0 } ],
+          "columns": [
+            null,
+            {% for tool in report %}
+            { "orderDataType": "test-status" },
+            {% endfor %}
+          ]
+        });
+      } );
     </script>
 
     <!-- override some defautl styles -->
     <style type="text/css">
-        table.dataTable {
-            width: auto;
-        }
+      table.dataTable {
+          width: auto;
+      }
 
-        .test-failed {
-          background-color: #ff6961;
-        }
-        .test-passed {
-          background-color: #89E894;
-        }
-        .test-na {
-          background-color: #cfcece;
-        }
+      .test-failed {
+        background-color: #ff6961;
+      }
+      .test-passed {
+        background-color: #89E894;
+      }
+      .test-na {
+        background-color: #cfcece;
+      }
 
     </style>
   </head>
@@ -139,7 +142,6 @@
         </tr>
       {% endfor %}
     </table>
-
   </body>
 
 </html>

--- a/conf/report-template.html
+++ b/conf/report-template.html
@@ -43,7 +43,7 @@
             }
 
             while (a_parts.length > b_parts.length) {
-                b_parts.push("1");
+                b_parts.push("0");
             }
 
             for (var i = 0; i < a_parts.length; i++) {

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -3,7 +3,6 @@
 from glob import glob
 import argparse
 import logging
-import pandas
 import jinja2
 import copy
 import sys
@@ -136,7 +135,7 @@ for r in [os.path.dirname(r) for r in glob(args.logs + "/*/")]:
         tags = data[r_name]["tags"]
 
         for tag in database:
-            tags[tag] = "?"
+            tags[tag] = "test-na"
 
         # generate tags summary
         for _, test in tests.items():
@@ -158,14 +157,14 @@ for r in [os.path.dirname(r) for r in glob(args.logs + "/*/")]:
 
             for tag in test["tags"].split(" "):
                 try:
-                    if tags[tag] == "-":
+                    if tags[tag] == "test-failed":
                         # already failed, don't overwrite
                         continue
 
                     if passed:
-                        tags[tag] = "+"
+                        tags[tag] = "test-passed"
                     else:
-                        tags[tag] = "-"
+                        tags[tag] = "test-failed"
                 except KeyError:
                     logger.warning("Tag not present in the database: " + tag)
                     continue
@@ -181,37 +180,11 @@ try:
         # and moving the tags info up
         data[r] = data[r]["tags"]
 
-    df = pandas.DataFrame(data=data)
-
-    def colorful_fields(val):
-        try:
-            color = 'color: '
-            if val == "+":
-                # green
-                color += "#89E894;"
-            elif val == "-":
-                # red
-                color += "#ff6961;"
-            else:
-                # gray
-                color += "#cfcece;"
-
-            color = "background-" + color * 2
-
-            return color
-        except:
-            return ""
-
-    # make the fields colorful
-    s = df.style.applymap(colorful_fields)
-
-    report_table = s.render(uuid="sv-test-report-table")
-
     with open(args.template, "r") as f:
         report = jinja2.Template(f.read())
 
     with open(args.out, 'w') as f:
-        f.write(report.render(report_table=report_table))
+        f.write(report.render(report=data, database=database))
 except KeyError:
     logger.critical("Unable to generate report, not enough logs")
 except Exception as e:


### PR DESCRIPTION
The result of the report generator is pretty much the same, but here is what changed and why:
* the `pandas` dependency was dropped - it was only used to generate the raw html table - we should be doing that by hand (with templates) to be able to fill all the individual cells with more details about the testcases and their results - this is a foundation for that.
Additionally without it it is easier to keep the formatting (colors etc) in the template instead of the python code.
* Cleaned up the template - the initial formatting was pretty inconsistent - this PR fixes that and adds a vim modeline at the begging to help avoid that in the future.