### PR TITLE
report: show logs upon clicking results cell

### DIFF
--- a/conf/report-template.html
+++ b/conf/report-template.html
@@ -111,16 +111,76 @@
 
       .test-failed {
         background-color: #ff6961;
+        cursor: pointer;
       }
       .test-passed {
         background-color: #89E894;
+        cursor: pointer;
       }
       .test-na {
         background-color: #cfcece;
       }
 
+      .logfile {
+        display: none;
+        position: fixed;
+        bottom: 0;
+        right: 10%;
+        left: 10%;
+        width: 80%;
+        height: 60%;
+        border: 2px solid black;
+        overflow-y: scroll;
+        overflow-x: hidden;
+        z-index: 10;
+        font-family: "Courier New", Courier, monospace;
+        cursor: text;
+      }
+      .logfile-close-btn {
+        float: right;
+        cursor: pointer;
+      }
+      .logfile-shown {
+        display: block;
+      }
+
     </style>
+
+    <script>
+      function toggleLog(div_id) {
+        all_logs = document.getElementsByClassName("logfile-shown");
+
+        for (var i=0; i < all_logs.length; ++i) {
+          if (all_logs[i].id != div_id) {
+            all_logs[i].classList.remove("logfile-shown");
+          }
+        }
+
+        log_div = document.getElementById(div_id);
+        log_div.classList.toggle("logfile-shown");
+      }
+
+      function hideLog(div_id) {
+        log_div = document.getElementById(div_id);
+        log_div.classList.remove("logfile-shown");
+      }
+    </script>
   </head>
+
+  {% for tag, info in database.items() %}
+  {% for tool, tooldata in report.items() %}
+  {% if "test-na" not in tooldata["tags"][tag]["status"] %}
+  <div class="logfile {{ tooldata["tags"][tag]["status"] }}"
+       id="{{ tool }}-{{ tag }}-logfile">
+    <div class="logfile-close-btn"
+         onclick='hideLog("{{ tool }}-{{ tag }}-logfile")'>
+      [X]
+    </div>
+    {{ tooldata["tags"][tag]["log"] }}
+  </div>
+  {% endif %}
+  {% endfor %}
+  {% endfor %}
 
   <body>
     <table id="report_table">
@@ -136,7 +196,11 @@
         <tr>
           <th> {{ tag }} </th>
           {% for tool, tooldata in report.items() %}
-          <th class="{{ tooldata[tag] }}">
+          <th class="{{ tooldata["tags"][tag]["status"] }}"
+            {% if "test-na" not in tooldata["tags"][tag]["status"] %}
+            onclick='toggleLog("{{ tool }}-{{ tag }}-logfile")'
+            {% endif %}
+            >
           </th>
           {% endfor %}
         </tr>

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -98,8 +98,8 @@ for r in [os.path.dirname(r) for r in glob(args.logs + "/*/")]:
 
         test_tags = ["name", "tags", "should_fail", "rc"]
         with open(t, "r") as f:
-            for l in f:
-                try:
+            try:
+                for l in f:
                     tag = re.search("^([a-zA-Z_-]+):(.+)", l)
 
                     if tag is None:
@@ -121,10 +121,13 @@ for r in [os.path.dirname(r) for r in glob(args.logs + "/*/")]:
                                 "Skipping unknown parameter: {} in {}"
                                 .format(param, t))
 
-                except Exception as e:
-                    logger.warning("Skipping " + t + " on " + r_name + ": " + str(e))
-                    del tests[t_name]
-                    break
+            except Exception as e:
+                logger.warning("Skipping " + t + " on " + r_name + ": " + str(e))
+                del tests[t_name]
+                continue
+
+            f.seek(0)
+            tests[t_name]["log"] = f.read()
 
         # check if test was skipped
         if t_name not in tests:
@@ -135,7 +138,8 @@ for r in [os.path.dirname(r) for r in glob(args.logs + "/*/")]:
         tags = data[r_name]["tags"]
 
         for tag in database:
-            tags[tag] = "test-na"
+            tags[tag] = {}
+            tags[tag]["status"] = "test-na"
 
         # generate tags summary
         for _, test in tests.items():
@@ -157,28 +161,30 @@ for r in [os.path.dirname(r) for r in glob(args.logs + "/*/")]:
 
             for tag in test["tags"].split(" "):
                 try:
-                    if tags[tag] == "test-failed":
+                    if tags[tag]["status"] == "test-failed":
                         # already failed, don't overwrite
                         continue
 
                     if passed:
-                        tags[tag] = "test-passed"
+                        tags[tag]["status"] = "test-passed"
                     else:
-                        tags[tag] = "test-failed"
+                        tags[tag]["status"] = "test-failed"
                 except KeyError:
                     logger.warning("Tag not present in the database: " + tag)
                     continue
 
-# for now just drop all the extra data and generate a very simple html
-# just use the number of passed tests as a PASS/FAIL result
-
 try:
     for r in data:
-        # so for now we're droppung all the detailed test info
-        del data[r]["tests"]
+        for tag in data[r]["tags"]:
+            tag_handle= data[r]["tags"][tag]
 
-        # and moving the tags info up
-        data[r] = data[r]["tags"]
+            tag_handle["log"] = ""
+
+            for test in data[r]["tests"]:
+                test_handle = data[r]["tests"][test]
+                if tag in test_handle["tags"].split():
+                    tag_handle["log"] += test_handle["log"] + "\n\n"
+            tag_handle["log"] = tag_handle["log"].replace("\n", "</br>")
 
     with open(args.template, "r") as f:
         report = jinja2.Template(f.read())


### PR DESCRIPTION
Users can now click the cells which indicate that there are some test
results. Clicking them will show an overlay with the test results and
test logs.

Signed-off-by: Tomasz Gorochowik <tgorochowik@antmicro.com>