### PR TITLE
Improve Makefile target generation performance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@ OUT_DIR=./out/
 TESTS_DIR=./tests
 RUNNERS_DIR=./runners
 
+export OUT_DIR
+export TESTS_DIR
+export RUNNERS_DIR
+
 clean:
 	@echo -e "Removing $(OUT_DIR)"
 	@rm -rf $(OUT_DIR)
@@ -14,33 +18,11 @@ ifneq (,$(wildcard $(OUT_DIR)/*))
 endif
 	@mkdir -p $(addprefix $(OUT_DIR), $(RUNNERS))
 
-define parse_param
-	$(eval $(1):=$(shell grep -m 1 :$1: $2 | cut -d' ' -f2-))
-endef
-
 # $(1) - runner name
 # $(2) - test
 define runner_gen
-
 $(1)_$(2): info init
-	$(call parse_param,name,$(TESTS_DIR)/$(2))
-	$(call parse_param,should_fail,$(TESTS_DIR)/$(2))
-	$(call parse_param,tags,$(TESTS_DIR)/$(2))
-	@echo "NAME: $(name)" > $(OUT_DIR)/$(1)/$(2).log
-	@echo "TAGS: $(tags)" >> $(OUT_DIR)/$(1)/$(2).log
-	@echo "SHOULD_FAIL: $(should_fail)" >> $(OUT_DIR)/$(1)/$(2).log
-	$(eval TMPDIR:=$(shell mktemp -d))
-	$(eval RUNNER_PATH:=$(abspath $(RUNNERS_DIR)/$(1)))
-	$(eval TEST_PATH:=$(abspath $(TESTS_DIR)/$(2)))
-	$(eval RC:=$(shell cd $(TMPDIR) && $(RUNNER_PATH) $(TEST_PATH) >> $(1).log 2>&1; echo $$?))
-	@echo "RC: $(RC)" >> $(OUT_DIR)/$(1)/$(2).log
-	@cat $(TMPDIR)/$(1).log >> $(OUT_DIR)/$(1)/$(2).log
-	@if [[ $(should_fail) == "0" && $(RC) == "0" ]] || [[ $(should_fail) == "1" && $(RC) != "0" ]]; then \
-		echo -e "Testing $(2) with $(1):\tPASS"; \
-	else \
-		echo -e "Testing $(2) with $(1):\tFAIL"; \
-	fi
-	@rm -r $(TMPDIR)
+	@./tools/runner $(1) $(2)
 
 tests: $(1)_$(2)
 endef

--- a/tools/runner
+++ b/tools/runner
@@ -1,0 +1,42 @@
+#!/bin/env bash
+
+RUNNER="$1"
+TEST="$2"
+
+function parse_param() {
+	echo $(grep -m 1 :$1: $2 | cut -d' ' -f2-)
+}
+
+
+name=$(parse_param name "${TESTS_DIR}/${TEST}")
+should_fail=$(parse_param should_fail "${TESTS_DIR}/${TEST}")
+tags=$(parse_param tags "${TESTS_DIR}/${TEST}")
+
+echo "NAME: ${name}" > "${OUT_DIR}/${RUNNER}/${TEST}.log"
+echo "TAGS: ${tags}" >> "${OUT_DIR}/${RUNNER}/${TEST}.log"
+echo "SHOULD_FAIL: ${should_fail}" >> ${OUT_DIR}/${RUNNER}/${TEST}.log
+
+TMPDIR=$(mktemp -d)
+
+RUNNER_PATH=$(readlink -f "${RUNNERS_DIR}/${RUNNER}")
+
+TEST_PATH=$(readlink -f  "${TESTS_DIR}/${TEST}")
+
+cd "${TMPDIR}" > /dev/null
+
+"${RUNNER_PATH}" "${TEST_PATH}" >> ${RUNNER}.log 2>&1
+RC=$?
+
+cd - > /dev/null
+
+echo "RC: ${RC}" >> "${OUT_DIR}/${RUNNER}/${TEST}.log"
+
+cat "${TMPDIR}/${RUNNER}.log" >> "${OUT_DIR}/${RUNNER}/${TEST}.log"
+
+if [[ ${should_fail} == "0" && ${RC} == "0" ]] || [[ ${should_fail} == "1" && ${RC} != "0" ]]; then
+  echo -e "Testing ${TEST} with ${RUNNER}:\tPASS";
+else
+  echo -e "Testing ${TEST} with ${RUNNER}:\tFAIL";
+fi
+
+rm -r "${TMPDIR}"


### PR DESCRIPTION
This significantly reduces the time of generating the targets given
there is a large number of tests.

For example for ~300 tests, the generation alone takes about 1 minute
and 30 seconds.

With this change it is almost instant.

Signed-off-by: Tomasz Gorochowik <tgorochowik@antmicro.com>