### PR TITLE
runners: add simple slang runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ make tests
 * [Odin II](https://verilogtorouting.org/)
 * [Verilator](https://www.veripool.org/wiki/verilator)
 * [Icarus](http://iverilog.icarus.com/)
+* [slang](https://github.com/MikePopoloski/slang)
 
 ## Assumptions
 

--- a/runners/slang
+++ b/runners/slang
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+driver $1


### PR DESCRIPTION
This adds a simple driver for [slang](https://github.com/MikePopoloski/slang)
This assumes that slang SystemVerilog compiler `driver` is located in `PATH`