### PR TITLE
report: allow the log overlay to be smaller

### DIFF
--- a/conf/report-template.html
+++ b/conf/report-template.html
@@ -138,7 +138,7 @@
         right: 10%;
         left: 10%;
         width: 80%;
-        height: 60%;
+        max-height: 60%;
         border: 2px solid black;
         overflow-y: scroll;
         overflow-x: hidden;


### PR DESCRIPTION
There is no need to force the log overlay to occupy 60% of the screen
when there is little to be displayed.

For example:
![2019-08-19-173638](https://user-images.githubusercontent.com/8438531/63279457-4b4b5300-c2a9-11e9-8558-d4b38a53b2a5.png)

(in this case the tool shows no logs, as it doesn't by default if it succeeded)