### PR TITLE
Tabs for logfiles

### DIFF
--- a/conf/report-template.html
+++ b/conf/report-template.html
@@ -113,19 +113,18 @@
         width: calc(100% / {{ report.keys()|length + 1}} );
       }
 
-      .test-failed {
-        background-color: #ff6961;
-        cursor: pointer;
+      .test-cell {
         border: 1px;
         border-color: #505050;
         border-style: dotted;
+        cursor: pointer;
+      }
+
+      .test-failed {
+        background-color: #ff6961;
       }
       .test-passed {
         background-color: #89E894;
-        cursor: pointer;
-        border: 1px;
-        border-color: #505050;
-        border-style: dotted;
       }
       .test-na {
         background-color: #cfcece;
@@ -140,19 +139,54 @@
         width: 80%;
         max-height: 60%;
         border: 2px solid black;
-        overflow-y: scroll;
+        overflow-y: hidden;
         overflow-x: hidden;
         z-index: 10;
         font-family: "Courier New", Courier, monospace;
+      }
+      .logfile-inner {
+        overflow-y: scroll;
+        overflow-x: hidden;
+        max-height: calc(60vh - 50px);
+        display: none;
         cursor: text;
       }
-      .logfile-close-btn {
+      .logtab-bar {
+        background-color: #666;
+        height: 50px;
+        min-height: 50px;
+      }
+      .logtab-btn {
+        padding: 4px;
+        margin: 0px;
+        cursor: pointer;
+        font-size: 17px;
+        height: 100%;
+        border: 2px solid #666;
+      }
+      .logtab-close-btn {
+        background: #cfcece;
         float: right;
+      }
+      .logtab-tab-btn {
+        float: left;
+      }
+      .logtab-btn-selected {
+        border-top: 0px;
+      }
+      .logfile-tab {
+        z-index: 11;
+        float: left;
         cursor: pointer;
       }
       .logfile-shown {
         display: block;
       }
+      .logtab-shown {
+        display: block;
+      }
+
+      button:focus {outline:0;}
 
     </style>
 
@@ -174,19 +208,71 @@
         log_div = document.getElementById(div_id);
         log_div.classList.remove("logfile-shown");
       }
+
+      function selectTab(group, test, btn_id) {
+        all_tabs = document.getElementsByClassName(group);
+        tab_id = group + "-" + test;
+
+        all_btns = document.getElementsByClassName("logtab-btn-selected");
+
+        for (var i=0; i < all_btns.length; ++i) {
+          if (all_btns[i].parentElement.id == group + "-bar") {
+            if (all_btns[i].id != btn_id) {
+              all_btns[i].classList.remove("logtab-btn-selected");
+            }
+          }
+        }
+
+        for (var i=0; i < all_tabs.length; ++i) {
+          if (all_tabs[i].id != tab_id) {
+            all_tabs[i].classList.remove("logtab-shown");
+          }
+        }
+
+        chosen_tab = document.getElementById(tab_id);
+        chosen_tab.classList.toggle("logtab-shown");
+
+        btn = document.getElementById(btn_id);
+
+        btn.classList.toggle("logtab-btn-selected");
+      }
     </script>
   </head>
 
   {% for tag, info in database.items() %}
   {% for tool, tooldata in report.items() %}
   {% if "test-na" not in tooldata["tags"][tag]["status"] %}
-  <div class="logfile {{ tooldata["tags"][tag]["status"] }}"
+  <div class="logfile"
        id="{{ tool }}-{{ tag }}-logfile">
-    <div class="logfile-close-btn"
-         onclick='hideLog("{{ tool }}-{{ tag }}-logfile")'>
-      [X]
+    {% for test, output in tooldata["tags"][tag]["logs"].items() %}
+    <div id="logtab-{{tool}}-{{tag}}-{{test}}"
+         class="logtab-{{tool}}-{{tag}} logfile-inner
+                {% if loop.first %} logtab-shown {% endif %}
+                {{output["status"]}}">
+    {{output["log"]}}
     </div>
-    {{ tooldata["tags"][tag]["log"] }}
+    {% endfor %}
+    <div class="logtab-bar"
+         id="logtab-{{tool}}-{{tag}}-bar">
+      {% for test, output in tooldata["tags"][tag]["logs"].items() %}
+      <button class="logtab-btn
+                     logtab-tab-btn
+                     {{output["status"]}}
+                     {% if loop.first %} logtab-btn-selected {% endif %}
+                     "
+              id="logtab-btn-{{tool}}-{{tag}}-{{test}}"
+              onclick='selectTab("logtab-{{tool}}-{{tag}}",
+                                 "{{test}}",
+                                 "logtab-btn-{{tool}}-{{tag}}-{{test}}")'
+        >
+        {{ test }}</button>
+      {% endfor %}
+
+      <button class="logtab-btn logtab-close-btn"
+              onclick='hideLog("{{ tool }}-{{ tag }}-logfile")'>
+        close
+      </button>
+    </div>
   </div>
   {% endif %}
   {% endfor %}
@@ -206,7 +292,8 @@
         <tr>
           <th> {{ tag }} </th>
           {% for tool, tooldata in report.items() %}
-          <th class="{{ tooldata["tags"][tag]["status"] }}"
+          <th class="{{ tooldata["tags"][tag]["status"] }}
+            {% if "test-na" not in tooldata["tags"][tag]["status"] %} test-cell {% endif %}"
             {% if "test-na" not in tooldata["tags"][tag]["status"] %}
             onclick='toggleLog("{{ tool }}-{{ tag }}-logfile")'
             {% endif %}

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -4,7 +4,6 @@ from glob import glob
 import argparse
 import logging
 import jinja2
-import copy
 import sys
 import os
 import re
@@ -60,15 +59,15 @@ database = {}
 try:
     with open(args.input) as f:
         for l in f:
-            l = l.strip()
+            ls = l.strip()
             # skip lines with comments
-            if re.search("^\s*#.*", l) is not None:
+            if re.search(r"^\s*#.*", ls) is not None:
                 continue
 
-            entry = l.split("\t")
+            entry = ls.split("\t")
 
             if len(entry) < 2:
-                raise KeyError("Invalid entry: " + l)
+                raise KeyError("Invalid entry: " + ls)
 
             database[entry[0]] = "\t".join(entry[1:])
 except KeyError as e:
@@ -100,7 +99,7 @@ for r in [os.path.dirname(r) for r in glob(args.logs + "/*/")]:
         with open(t, "r") as f:
             try:
                 for l in f:
-                    tag = re.search("^([a-zA-Z_-]+):(.+)", l)
+                    tag = re.search(r"^([a-zA-Z_-]+):(.+)", l)
 
                     if tag is None:
                         raise KeyError("Could not find tags: {}"
@@ -122,7 +121,8 @@ for r in [os.path.dirname(r) for r in glob(args.logs + "/*/")]:
                                 .format(param, t))
 
             except Exception as e:
-                logger.warning("Skipping " + t + " on " + r_name + ": " + str(e))
+                logger.warning("Skipping {} on {}: {}"
+                               .format(t, r_name, str(e)))
                 del tests[t_name]
                 continue
 
@@ -176,7 +176,7 @@ for r in [os.path.dirname(r) for r in glob(args.logs + "/*/")]:
 try:
     for r in data:
         for tag in data[r]["tags"]:
-            tag_handle= data[r]["tags"][tag]
+            tag_handle = data[r]["tags"][tag]
 
             tag_handle["log"] = ""
 

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -152,6 +152,8 @@ for r in [os.path.dirname(r) for r in glob(args.logs + "/*/")]:
             if tool_should_fail != tool_failed:
                 passed = False
 
+            test["status"] = "test-" + ("passed" if passed else "failed")
+
             if passed:
                 logger.debug("{} passed {} in {}"
                              .format(r_name, test["tags"], test["name"]))
@@ -178,13 +180,15 @@ try:
         for tag in data[r]["tags"]:
             tag_handle = data[r]["tags"][tag]
 
-            tag_handle["log"] = ""
+            tag_handle["logs"] = {}
 
             for test in data[r]["tests"]:
                 test_handle = data[r]["tests"][test]
                 if tag in test_handle["tags"].split():
-                    tag_handle["log"] += test_handle["log"] + "\n\n"
-            tag_handle["log"] = tag_handle["log"].replace("\n", "</br>")
+                    tag_handle["logs"][test_handle["name"]] = {}
+                    inner = tag_handle["logs"][test_handle["name"]]
+                    inner["log"] = test_handle["log"].replace("\n", "</br>")
+                    inner["status"] = test_handle["status"]
 
     with open(args.template, "r") as f:
         report = jinja2.Template(f.read())


### PR DESCRIPTION
Instead of concatenating the logs for all test-cases, create tabs to allow viewers to switch between logs of individual tests.

This allows users to quickly find the test that actually failed.

For example:

![2019-08-20-154200](https://user-images.githubusercontent.com/8438531/63352439-6a0d2080-c361-11e9-9fc4-5a1d9190ae01.png)

Next step:
Make the cells which contain both successful and unsuccessful test distinguishable - e.g. make them yellow/orange.

Note: this PR also induces a commit with some PEP8 fixes for the report generator script.
