### PR TITLE
explicitly mark features with varied results

### DIFF
--- a/conf/report-template.html
+++ b/conf/report-template.html
@@ -83,7 +83,11 @@
             return 2;
           }
 
-          return 3;
+          if (td.className.includes("test-varied")) {
+            return 3;
+          }
+
+          return 4;
         });
       };
     </script>
@@ -125,6 +129,9 @@
       }
       .test-passed {
         background-color: #89E894;
+      }
+      .test-varied {
+        background-color: #ffd761;
       }
       .test-na {
         background-color: #cfcece;

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -139,7 +139,7 @@ for r in [os.path.dirname(r) for r in glob(args.logs + "/*/")]:
 
         for tag in database:
             tags[tag] = {}
-            tags[tag]["status"] = "test-na"
+            tags[tag]["status"] = []
 
         # generate tags summary
         for _, test in tests.items():
@@ -152,7 +152,8 @@ for r in [os.path.dirname(r) for r in glob(args.logs + "/*/")]:
             if tool_should_fail != tool_failed:
                 passed = False
 
-            test["status"] = "test-" + ("passed" if passed else "failed")
+            status = "test-" + ("passed" if passed else "failed")
+            test["status"] = status
 
             if passed:
                 logger.debug("{} passed {} in {}"
@@ -163,17 +164,18 @@ for r in [os.path.dirname(r) for r in glob(args.logs + "/*/")]:
 
             for tag in test["tags"].split(" "):
                 try:
-                    if tags[tag]["status"] == "test-failed":
-                        # already failed, don't overwrite
-                        continue
-
-                    if passed:
-                        tags[tag]["status"] = "test-passed"
-                    else:
-                        tags[tag]["status"] = "test-failed"
+                    tags[tag]["status"].append(status)
                 except KeyError:
                     logger.warning("Tag not present in the database: " + tag)
                     continue
+
+        for tag in tags:
+            if len(tags[tag]["status"]) == 0:
+                tags[tag]["status"] = "test-na"
+            elif all(tags[tag]["status"][0] == x for x in tags[tag]["status"]):
+                tags[tag]["status"] = tags[tag]["status"][0]
+            else:
+                tags[tag]["status"] = "test-varied"
 
 try:
     for r in data:


### PR DESCRIPTION
If one feature is tested by more than one test and the results of the tests vary, it should be clearly visible in the report.
    
This PR marks such features with orange.

![2019-08-20-164604](https://user-images.githubusercontent.com/8438531/63357818-5b773700-c36a-11e9-9882-f79e9d5096e4.png)

Depends on #14 (and includes patches from there), feel free to comment but do not merge yet.
