### PR TITLE
Make the makefile output more verbose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ tests:
 
 report: init tests
 	@echo -e "\nGenerating report"
-	@./tools/sv-report --quiet
+	@./tools/sv-report
 	@echo -e "\nDONE!"
 
 $(foreach r, $(RUNNERS),$(foreach t, $(TESTS),$(eval $(call runner_gen,$(r),$(t)))))

--- a/tools/runner
+++ b/tools/runner
@@ -87,6 +87,9 @@ except (PermissionError, FileExistsError) as e:
     sys.exit(1)
 
 try:
+    logger.info("Running {}/{}"
+                .format(args.runner, args.test))
+
     proc = subprocess.Popen([runner, test], cwd=tmp_dir,
                             stdout=subprocess.PIPE,
                             stderr=subprocess.STDOUT)
@@ -94,6 +97,16 @@ try:
     output, _ = proc.communicate()
 
     test_params['rc'] = proc.returncode
+
+    tool_should_fail = test_params["should_fail"] == "1"
+    tool_failed = test_params["rc"] != "0"
+
+    test_passed = tool_should_fail == tool_failed
+
+    if test_passed:
+        logger.info("PASS: {}/{}".format(args.runner, args.test))
+    else:
+        logger.warning("FAIL: {}/{}".format(args.runner, args.test))
 
     with open(out, "w") as log:
         # start by writing params

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -95,7 +95,7 @@ for r in [os.path.dirname(r) for r in glob(args.logs + "/*/")]:
         tests[t_name] = {}
         tests[t_name]["path"] = t
 
-        test_tags = ["name", "tags", "should_fail", "rc"]
+        test_tags = ["name", "tags", "should_fail", "rc", "description"]
         with open(t, "r") as f:
             try:
                 for l in f:


### PR DESCRIPTION
When there are many results and test cases it is better to see some more output. Otherwise it may seem that the process just gets stuck.

Output after the patches from this PR:
```
$ make -j13
Found the following runners:
 * icarus
 * verilator
 * odin
 * slang
 * yosys
 * fake

Found the following tests:
 * counter.sv
 * always.sv
 * typedef.sv
 * sanity.sv

INFO    | Running icarus/counter.sv
INFO    | Running verilator/always.sv
INFO    | Running verilator/typedef.sv
INFO    | Running icarus/always.sv
INFO    | Running icarus/sanity.sv
INFO    | Running icarus/typedef.sv
INFO    | Running odin/counter.sv
INFO    | Running verilator/sanity.sv
INFO    | Running odin/sanity.sv
INFO    | Running odin/typedef.sv
WARNING | FAIL: icarus/counter.sv
WARNING | FAIL: odin/counter.sv
INFO    | PASS: odin/sanity.sv
INFO    | Running slang/counter.sv
INFO    | PASS: icarus/sanity.sv
INFO    | Running verilator/counter.sv
WARNING | FAIL: icarus/always.sv
WARNING | FAIL: odin/typedef.sv
WARNING | FAIL: slang/counter.sv
INFO    | Running odin/always.sv
WARNING | FAIL: icarus/typedef.sv
WARNING | FAIL: odin/always.sv
INFO    | Running slang/always.sv
INFO    | Running slang/typedef.sv
INFO    | Running slang/sanity.sv
INFO    | Running yosys/counter.sv
WARNING | FAIL: verilator/always.sv
WARNING | FAIL: slang/always.sv
WARNING | FAIL: verilator/typedef.sv
INFO    | PASS: verilator/sanity.sv
INFO    | PASS: slang/sanity.sv
INFO    | Running yosys/typedef.sv
WARNING | FAIL: slang/typedef.sv
INFO    | Running yosys/sanity.sv
INFO    | Running yosys/always.sv
WARNING | FAIL: yosys/counter.sv
WARNING | FAIL: yosys/typedef.sv
INFO    | Running fake/counter.sv
WARNING | FAIL: yosys/always.sv
INFO    | PASS: yosys/sanity.sv
WARNING | FAIL: verilator/counter.sv
WARNING | FAIL: fake/counter.sv
INFO    | Running fake/always.sv
WARNING | FAIL: fake/always.sv
INFO    | Running fake/sanity.sv
INFO    | Running fake/typedef.sv
INFO    | PASS: fake/sanity.sv
WARNING | FAIL: fake/typedef.sv

Generating report
INFO    | Generating out/report.html from log files in 'out'

DONE!
```