### PR TITLE
tools: Change env binary location to /usr/bin

### DIFF
--- a/tools/runner
+++ b/tools/runner
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 
 import os
 import re

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 
 from glob import glob
 import argparse


### PR DESCRIPTION
Change to /usr/bin location as it is more popular across different Linux distributions. Also it fixes execution errors when running on Ubuntu 18.04.2.