### PR TITLE
[WIP] Add Icarus Verilog simulation runner

### DIFF
--- a/runners/fake
+++ b/runners/fake
@@ -1,4 +1,5 @@
 #!/bin/bash
+#:type: syntax
 
 echo "I AM A FAKE RUNNER!"
 echo "MY INVOKATION ARGS: $@"

--- a/runners/icarus
+++ b/runners/icarus
@@ -1,3 +1,4 @@
 #!/bin/bash
+#:type: syntax
 
 iverilog -g2012 -o iverilog.out $1

--- a/runners/icarus-sim
+++ b/runners/icarus-sim
@@ -1,4 +1,5 @@
 #!/bin/bash
+#:type: simulation
 
 OUT="iverilog.out"
 

--- a/runners/icarus-sim
+++ b/runners/icarus-sim
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+OUT="iverilog.out"
+
+iverilog -g2012 -o $OUT $1
+vvp $OUT

--- a/runners/odin
+++ b/runners/odin
@@ -1,3 +1,4 @@
 #!/bin/bash
+#:type: syntax
 
 odin_II --permissive -V $1 -o odin.blif

--- a/runners/slang
+++ b/runners/slang
@@ -1,3 +1,4 @@
 #!/bin/bash
+#:type: syntax
 
 driver $1

--- a/runners/verilator
+++ b/runners/verilator
@@ -1,3 +1,4 @@
 #!/bin/bash
+#:type: syntax
 
 verilator --cc $1

--- a/runners/yosys
+++ b/runners/yosys
@@ -1,3 +1,4 @@
 #!/bin/bash
+#:type: syntax
 
 yosys -p "read_verilog -sv $1"

--- a/tests/always.sv
+++ b/tests/always.sv
@@ -3,6 +3,7 @@
 :description: A module testing various structured procedures
 :should_fail: 0
 :tags: 9.2
+:steps: syntax
 */
 module always_tb (
 	clk,

--- a/tests/counter.sv
+++ b/tests/counter.sv
@@ -3,6 +3,7 @@
 :description: A simple counter module
 :should_fail: 0
 :tags: 5.2 5.3 5.4
+:steps: syntax
 */
 module counter_tb (
 	clk,

--- a/tests/sanity.sv
+++ b/tests/sanity.sv
@@ -3,6 +3,7 @@
 :description: A simple module that should fail during parsing
 :should_fail: 1
 :tags: sanity
+:steps: syntax
 */
 module sanity_tb (
 	clk,

--- a/tests/typedef.sv
+++ b/tests/typedef.sv
@@ -3,6 +3,7 @@
 :description: A module testing typedef support
 :should_fail: 0
 :tags: 6.18
+:steps: syntax
 */
 module typedef_tb (
 	clk,

--- a/tools/runner
+++ b/tools/runner
@@ -27,6 +27,44 @@ ch = logging.StreamHandler()
 ch.setFormatter(logging.Formatter('%(levelname)-8s| %(message)s'))
 logger.addHandler(ch)
 
+
+def parse_params(file_path, req_params):
+    # look for all required params
+    result = {}
+    try:
+        with open(file_path) as f:
+            for l in f:
+                param = re.search(r":([a-zA-Z_-]+):\s*(.+)", l)
+
+                if param is None:
+                    continue
+
+                param_name = param.group(1).lower()
+                param_value = param.group(2)
+
+                if param_name not in req_params:
+                    logger.warning("Unsupported param found: {} - ignoring"
+                                   .format(param_name))
+                    continue
+
+                result[param_name] = param_value
+
+                if len(set(req_params) - set(result.keys())) == 0:
+                    # all parameters found
+                    break
+
+            else:
+                missing = list(set(req_params) - set(result.keys()))
+                logger.error("Required parameters missing ({}) in {}"
+                             .format(", ".join(missing), file_path))
+                sys.exit(1)
+    except Exception as e:
+        logger.error("Unable to parse test file: {}".format(str(e)))
+        sys.exit(1)
+
+    return result
+
+
 dirs = {}
 
 try:
@@ -43,41 +81,17 @@ out = os.path.abspath(os.path.join(dirs['out'],
                       args.runner,
                       args.test + ".log"))
 
-req_test_params = ["name", "tags", "description", "should_fail"]
+req_test_params = ["name", "tags", "description", "should_fail", "steps"]
+req_runner_params = ["type"]
 
-test_params = {}
+test_params = parse_params(test, req_test_params)
+runner_params = parse_params(runner, req_runner_params)
 
-# look for all required params
-try:
-    with open(test) as f:
-        for l in f:
-            param = re.search(r"^:([a-zA-Z_-]+):\s*(.+)", l)
+if runner_params["type"] not in test_params["steps"].split():
+    logger.debug("Skipping {}/{}, step {}"
+                 .format(args.runner, args.test, runner_params["type"]))
 
-            if param is None:
-                continue
-
-            param_name = param.group(1).lower()
-            param_value = param.group(2)
-
-            if param_name not in req_test_params:
-                logger.warning("Unsupported test param found: {} - ignoring"
-                               .format(param_name))
-                continue
-
-            test_params[param_name] = param_value
-
-            if len(set(req_test_params) - set(test_params.keys())) == 0:
-                # all parameters found
-                break
-
-        else:
-            missing = list(set(req_test_params) - set(test_params.keys()))
-            logger.error("Required parameters missing ({}) in {}"
-                         .format(", ".join(missing), args.test))
-            sys.exit(1)
-except Exception as e:
-    logger.error("Unable to parse test file: {}".format(str(e)))
-    sys.exit(1)
+    sys.exit(0)
 
 try:
     tmp_dir = tempfile.mkdtemp()


### PR DESCRIPTION
Current Icarus runner only checks if the file gets successfully parsed but we should also check if it simulates successfully.
To achieve that test cases must be designed in such a way that if results match what was expected 
`:PASSED:` should be printed on simulator output.
In case the file tests only syntax it should contain an `initial` block with `$display(":PASSED:")` inside which would allow it to pass simulation test if it is parsed correctly.