### PR TITLE
Hide yosys banners

### DIFF
--- a/runners/yosys
+++ b/runners/yosys
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-yosys -p "read_verilog -sv $1"
+yosys -Q -T -p "read_verilog -sv $1"


### PR DESCRIPTION
There is lots of tests and including the banners in each log for yosys is pointless and makes the logs much less readable.