### PR TITLE
verilator: don't fail because of warnings

### DIFF
--- a/runners/verilator
+++ b/runners/verilator
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-verilator --cc $1
+verilator -Wno-fatal --cc $1


### PR DESCRIPTION
Warnings should be accepted for syntax-checking tests.

The list warnings that verilator fails on without this flag include:
 * implicit type conversions
 * multiple top modules

So situations that are perfectly valid in terms of syntax.