### PR TITLE
tools: fix issue with tests erroneously being logged as failed

### DIFF
--- a/tools/runner
+++ b/tools/runner
@@ -99,7 +99,7 @@ try:
     test_params['rc'] = proc.returncode
 
     tool_should_fail = test_params["should_fail"] == "1"
-    tool_failed = test_params["rc"] != "0"
+    tool_failed = test_params["rc"] != 0
 
     test_passed = tool_should_fail == tool_failed
 


### PR DESCRIPTION
When test was marked as `:should_fail: 0` it would show in logs as failed
regardless of return code due to error in return code comparison