### PR TITLE
Improve the log file tabs in the report

### DIFF
--- a/conf/report-template.html
+++ b/conf/report-template.html
@@ -145,35 +145,36 @@
         display: none;
         position: fixed;
         bottom: 0;
-        right: 10%;
-        left: 10%;
-        width: 80%;
-        max-height: 60%;
+        left: 1.5%;
+        width: 97%;
+        max-height: 80%;
         border: 2px solid black;
         overflow-y: hidden;
         overflow-x: hidden;
         z-index: 10;
         font-family: "Courier New", Courier, monospace;
+        background-color: #666;
       }
       .logfile-inner {
         overflow-y: scroll;
         overflow-x: hidden;
-        max-height: calc(60vh - 50px);
+        max-height: calc(60vh);
+        border-bottom: 1px solid black;
         display: none;
         cursor: text;
       }
       .logtab-bar {
-        background-color: #666;
-        height: 50px;
-        min-height: 50px;
+        overflow-y: scroll;
+        max-height: calc(20vh);
       }
       .logtab-btn {
-        padding: 4px;
         margin: 0px;
         cursor: pointer;
-        font-size: 17px;
-        height: 100%;
         border: 2px solid #666;
+        overflow:hidden;
+        text-overflow: ellipsis;
+        width: 12.5%;
+        white-space: nowrap;
       }
       .logtab-close-btn {
         background: #cfcece;
@@ -183,7 +184,8 @@
         float: left;
       }
       .logtab-btn-selected {
-        border-top: 0px;
+        border: 2px solid black;
+        font-weight: bold;
       }
       .logfile-tab {
         z-index: 11;
@@ -273,6 +275,10 @@
     {% endfor %}
     <div class="logtab-bar"
          id="logtab-{{tool}}-{{tag}}-bar">
+      <button class="logtab-btn logtab-close-btn"
+              onclick='hideLog("{{ tool }}-{{ tag }}-logfile")'>
+        close
+      </button>
       {% for test, output in tooldata["tags"][tag]["logs"].items() %}
       <button class="logtab-btn
                      logtab-tab-btn
@@ -286,11 +292,6 @@
         >
         {{ test }}</button>
       {% endfor %}
-
-      <button class="logtab-btn logtab-close-btn"
-              onclick='hideLog("{{ tool }}-{{ tag }}-logfile")'>
-        close
-      </button>
     </div>
   </div>
   {% endif %}


### PR DESCRIPTION
The tabs in the report looked good when there are just a few tests:

![good](https://user-images.githubusercontent.com/8438531/63586733-61eff380-c5a2-11e9-9327-b8b8684cceb3.png)

However when there are lots and lots of tests (Tested with tests from #21), they are pretty much unusable:

![bad](https://user-images.githubusercontent.com/8438531/63586976-112cca80-c5a3-11e9-9869-ddd1ae143d78.png)

This PR addressees this issue by:
* making the tabs smaller (both in terms of font and padding)
* making the tabs fixed size (arbitrarily chosen 8 tabs per line - this could be adjusted)
* adding a scrollbar to when there is lots of tabs
* changing the method the selected window is highlighted - previously the tab was _merged_ with the log window - it looked pretty and cool if there was just one row of tabs, but this just doesn't scale to multiple rows. Right now the selected tab gets a thicker border and a bold font.
* allowing the log window to occupy more space that was allowed earlier
* trimming the name on the tab if it is too long

Here is how it looks now:
![post](https://user-images.githubusercontent.com/8438531/63586945-ffe3be00-c5a2-11e9-8f83-301397ca6329.png)


And when there is fewer tests it still looks acceptable:
![post-few](https://user-images.githubusercontent.com/8438531/63586941-fa867380-c5a2-11e9-9658-d551bbba25a1.png)
