### PR TITLE
Show more details in the report cells

### DIFF
--- a/conf/report-template.html
+++ b/conf/report-template.html
@@ -122,10 +122,15 @@
         border-color: #505050;
         border-style: dotted;
         cursor: pointer;
+
+        font-family: "Courier New", Courier, monospace;
+        font-size: 10px;
+        font-weight: normal;
       }
 
       .test-cell-selected {
         border: 2px solid black;
+        font-weight: bold;
       }
 
       .test-failed {
@@ -318,6 +323,9 @@
             onclick='toggleLog("{{ tool }}-{{ tag }}-logfile", "{{tool}}-{{tag}}-cell")'
             {% endif %}
             >
+            {% if "test-na" not in tooldata["tags"][tag]["status"] %}
+            {{ tooldata["tags"][tag]["passed-num"] }}/{{ tooldata["tags"][tag]["logs"]|length }}
+            {% endif %}
           </th>
           {% endfor %}
         </tr>

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -170,6 +170,8 @@ for r in [os.path.dirname(r) for r in glob(args.logs + "/*/")]:
                     continue
 
         for tag in tags:
+            tags[tag]["passed-num"] = tags[tag]["status"].count("test-passed")
+
             if len(tags[tag]["status"]) == 0:
                 tags[tag]["status"] = "test-na"
             elif all(tags[tag]["status"][0] == x for x in tags[tag]["status"]):


### PR DESCRIPTION
Show how many tests are there for individual features and how many of those passed for particular tools.

![2019-08-23-140855](https://user-images.githubusercontent.com/8438531/63591716-ded59a00-c5af-11e9-910f-495d05e45d27.png)

Note that the screenshot shows tests from #21 

A nice side-effect of this is being able search for `/` to display only the features with any tests.