### PR TITLE
Add names to the tags in the report

### DIFF
--- a/conf/report-template.html
+++ b/conf/report-template.html
@@ -8,6 +8,9 @@
     <title>SystemVerilog Report</title>
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script>
+    <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/themes/smoothness/jquery-ui.css">
+
     <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.19/css/jquery.dataTables.css">
     <script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/1.10.19/js/jquery.dataTables.min.js"></script>
 
@@ -115,6 +118,21 @@
       }
       table.dataTable tbody tr th {
         width: calc(100% / {{ report.keys()|length + 1}} );
+      }
+
+      .ui-widget-shadow {
+        -webkit-box-shadow: none;
+        box-shadow: none;
+      }
+
+      .ui-tooltip {
+        font-family: "Courier New", Courier, monospace;
+        font-size: 13px;
+        font-weight: normal;
+      }
+
+      .ui-corner-all {
+        border-radius: 0px;
       }
 
       .test-cell {
@@ -256,6 +274,16 @@
         btn.classList.toggle("logtab-btn-selected");
       }
     </script>
+
+    <script>
+      $(function() {
+        $(document).tooltip({
+          track: true,
+          show: 0,
+          hide: 0
+        });
+      });
+    </script>
   </head>
 
   {% for tag, info in database.items() %}
@@ -309,7 +337,7 @@
       </thead>
         {% for tag, info in database.items() %}
         <tr>
-          <th> {{ tag }} </th>
+          <th title="{{info}}"> {{ tag }} </th>
           {% for tool, tooldata in report.items() %}
           <th class="{{ tooldata["tags"][tag]["status"] }}
             {% if "test-na" not in tooldata["tags"][tag]["status"] %} test-cell {% endif %}"


### PR DESCRIPTION
When hovering the tag in the report table the description from the
database will appear in a tooltip.

For example:
![2019-08-23-161122](https://user-images.githubusercontent.com/8438531/63599572-2b29d580-c5c2-11e9-8b12-47baa7b267eb.png)

Closes #29