### PR TITLE
Makefile: fix dependencies between runner targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,8 @@ init:
 ifneq (,$(wildcard $(OUT_DIR)/*))
 	@echo -e "!!! WARNING !!!\nThe output directory is not empty\n"
 endif
-	@mkdir -p $(OUT_DIR)/runners/bin
 
-runners: init
+runners:
 
 # $(1) - runner name
 # $(2) - test

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ export GENERATORS_DIR
 
 include tools/runners.mk
 
+.PHONY: clean init info tests generate-tests report
+
 clean:
 	@echo -e "Removing $(OUT_DIR)"
 	@rm -rf $(OUT_DIR)

--- a/tools/runners.mk
+++ b/tools/runners.mk
@@ -14,9 +14,9 @@ $(INSTALL_DIR)/bin/odin_II: init
 	@cp $(RDIR)/odin_ii/ODIN_II/odin_II $(INSTALL_DIR)/bin/
 
 # yosys
-yosys: $(install_dir)/bin/yosys
+yosys: $(INSTALL_DIR)/bin/yosys
 
-$(install_dir)/bin/yosys: init
+$(INSTALL_DIR)/bin/yosys: init
 	@$(MAKE) -C $(RDIR)/yosys ENABLE_TCL=0 ENABLE_ABC=0 ENABLE_GLOB=0 ENABLE_PLUGINS=0 ENABLE_READLINE=0 ENABLE_COVER=0
 	@cp $(RDIR)/yosys/yosys $(INSTALL_DIR)/bin/
 

--- a/tools/runners.mk
+++ b/tools/runners.mk
@@ -54,4 +54,5 @@ $(INSTALL_DIR)/bin/driver:
 
 # setup the dependencies
 RUNNERS_TARGETS := odin yosys icarus verilator slang
+.PHONY: $(RUNNERS_TARGETS)
 runners: $(RUNNERS_TARGETS)

--- a/tools/runners.mk
+++ b/tools/runners.mk
@@ -9,21 +9,24 @@ runners:
 # odin
 odin: $(INSTALL_DIR)/bin/odin_II
 
-$(INSTALL_DIR)/bin/odin_II: init
+$(INSTALL_DIR)/bin/odin_II:
+	@mkdir -p $(OUT_DIR)/runners/bin
 	@$(MAKE) -C $(RDIR)/odin_ii/ODIN_II/ build
 	@cp $(RDIR)/odin_ii/ODIN_II/odin_II $(INSTALL_DIR)/bin/
 
 # yosys
 yosys: $(INSTALL_DIR)/bin/yosys
 
-$(INSTALL_DIR)/bin/yosys: init
+$(INSTALL_DIR)/bin/yosys:
+	@mkdir -p $(OUT_DIR)/runners/bin
 	@$(MAKE) -C $(RDIR)/yosys ENABLE_TCL=0 ENABLE_ABC=0 ENABLE_GLOB=0 ENABLE_PLUGINS=0 ENABLE_READLINE=0 ENABLE_COVER=0
 	@cp $(RDIR)/yosys/yosys $(INSTALL_DIR)/bin/
 
 # icarus
 icarus: $(INSTALL_DIR)/bin/iverilog
 
-$(INSTALL_DIR)/bin/iverilog: init
+$(INSTALL_DIR)/bin/iverilog:
+	@mkdir -p $(OUT_DIR)/runners/bin
 	@cd $(RDIR)/icarus && autoconf
 	@cd $(RDIR)/icarus && ./configure --prefix=$(abspath $(INSTALL_DIR))/
 	@$(MAKE) -C $(RDIR)/icarus
@@ -33,7 +36,8 @@ $(INSTALL_DIR)/bin/iverilog: init
 # verilator
 verilator: $(INSTALL_DIR)/bin/verilator
 
-$(INSTALL_DIR)/bin/verilator: init
+$(INSTALL_DIR)/bin/verilator:
+	@mkdir -p $(OUT_DIR)/runners/bin
 	@cd $(RDIR)/verilator && autoconf
 	@cd $(RDIR)/verilator && ./configure --prefix=$(abspath $(INSTALL_DIR))/
 	@$(MAKE) -C $(RDIR)/verilator
@@ -42,10 +46,12 @@ $(INSTALL_DIR)/bin/verilator: init
 # slang
 slang: $(INSTALL_DIR)/bin/driver
 
-$(INSTALL_DIR)/bin/driver: init
+$(INSTALL_DIR)/bin/driver:
+	@mkdir -p $(OUT_DIR)/runners/bin
 	@mkdir -p $(RDIR)/slang/build
 	@cd $(RDIR)/slang/build && cmake .. -DSLANG_INCLUDE_TESTS=OFF && make -j13
 	@cp $(RDIR)/slang/build/bin/* $(INSTALL_DIR)/bin/
 
 # setup the dependencies
-runners: $(addprefix $(INSTALL_DIR)/bin/,odin_II yosys iverilog verilator driver)
+RUNNERS_TARGETS := odin yosys icarus verilator slang
+runners: $(RUNNERS_TARGETS)


### PR DESCRIPTION
After adding the short names in 3c00f2b4a1ba, executing the 'runners' target always forced a rebuild of each runner. Fix the dependencies so that the tools are not rebuilt if the binary already exists.

This PR adds several Makefile target fixes, including the dependencies, a minor variable usage bug and marking the targets as PHONY where relevant.