### PR TITLE
Add information about the versions of the tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,13 @@ $(OUT_DIR)/logs/$(1)/$(2).log: $(TESTS_DIR)/$(2)
 tests: $(OUT_DIR)/logs/$(1)/$(2).log
 endef
 
+define runner_version_gen
+$(OUT_DIR)/logs/$(1)/version:
+	./tools/runner --runner $(1) --version --out $(OUT_DIR)/logs/$(1)/version
+
+versions: $(OUT_DIR)/logs/$(1)/version
+endef
+
 define generator_gen
 generate-$(1):
 	$(GENERATORS_DIR)/$(1) $(1)
@@ -78,10 +85,11 @@ tests:
 
 generate-tests:
 
-report: init tests
+report: init tests versions
 	./tools/sv-report --revision $(shell git rev-parse --short HEAD)
 	cp $(CONF_DIR)/report/*.css $(OUT_DIR)/report/
 	cp $(CONF_DIR)/report/*.js $(OUT_DIR)/report/
 
 $(foreach g, $(GENERATORS), $(eval $(call generator_gen,$(g))))
 $(foreach r, $(RUNNERS),$(foreach t, $(TESTS),$(eval $(call runner_gen,$(r),$(t)))))
+$(foreach r, $(RUNNERS),$(eval $(call runner_version_gen,$(r))))

--- a/conf/report/report-template.html
+++ b/conf/report/report-template.html
@@ -89,7 +89,7 @@
           <th>  </th>
           <th>  </th>
           {% for tool, tooldata in report|dictsort %}
-          <th> {{ tool.lower() }} </th>
+          <th title='{{ report[tool]["version"] }}'> {{ tool.lower() }} </th>
           {% endfor %}
         </tr>
       </thead>

--- a/conf/report/report.css
+++ b/conf/report/report.css
@@ -43,6 +43,8 @@ table.dataTable tfoot th {
   font-family: "Courier New", Courier, monospace;
   font-size: 13px;
   font-weight: normal;
+  white-space: pre-wrap;
+  max-width: 100%;
 }
 
 .ui-corner-all {

--- a/tools/BaseRunner.py
+++ b/tools/BaseRunner.py
@@ -64,3 +64,37 @@ class BaseRunner:
         Returns True when tool is installed and can be used, False otherwise.
         """
         return shutil.which(self.executable) is not None
+
+    def get_version_cmd(self):
+        """ Get version command
+
+        Returns a list containing the command and arguments needed to get the
+                version.
+        """
+
+        # assume sane defaults
+        return [self.executable, "--version"]
+
+    def get_version(self):
+        """Attempt to get the version of the tool
+
+        Returns a version string
+        """
+
+        try:
+            cmd = self.get_version_cmd()
+
+            proc = subprocess.Popen(
+                cmd,
+                preexec_fn=set_process_limits,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT)
+
+            log, _ = proc.communicate()
+
+            if proc.returncode != 0:
+                return self.name
+
+            return log.decode('utf-8')
+        except (TypeError, NameError, OSError):
+            return self.name

--- a/tools/runner
+++ b/tools/runner
@@ -14,7 +14,9 @@ parser = argparse.ArgumentParser()
 
 parser.add_argument("-r", "--runner", required=True)
 
-parser.add_argument("-t", "--test", required=True)
+action = parser.add_mutually_exclusive_group(required=True)
+action.add_argument("-t", "--test")
+action.add_argument("-v", "--version", action="store_true")
 
 parser.add_argument("-o", "--out", required=True)
 
@@ -61,8 +63,16 @@ new_path = [os.path.abspath(dirs['out'] + "/runners/bin/"), os.environ['PATH']]
 os.environ['PATH'] = ":".join(new_path)
 
 runner = os.path.abspath(os.path.join(dirs['runners'], args.runner))
-test = os.path.abspath(os.path.join(dirs['tests'], args.test))
 out = os.path.abspath(args.out)
+
+if args.version:
+    version = runner_obj.get_version()
+    with open(out, "w") as f:
+        f.write(version)
+
+    sys.exit(0)
+
+test = os.path.abspath(os.path.join(dirs['tests'], args.test))
 
 req_test_params = [
     "name", "tags", "description", "should_fail", "files", "incdirs",

--- a/tools/runners/Icarus.py
+++ b/tools/runners/Icarus.py
@@ -17,3 +17,14 @@ class Icarus(BaseRunner):
             self.cmd.append('-s ' + params['top_module'])
 
         self.cmd += params['files']
+
+    def get_version_cmd(self):
+        return [self.executable, "-V"]
+
+    def get_version(self):
+        version = super().get_version()
+
+        # The version is the 4th word in the 1st line
+        version = version.splitlines()[0].split()[3]
+
+        return " ".join([self.name, version])

--- a/tools/runners/Odin.py
+++ b/tools/runners/Odin.py
@@ -18,3 +18,15 @@ class Odin(BaseRunner):
             self.cmd.append('--top_module ' + params['top_module'])
 
         self.cmd += params['files']
+
+    def get_version_cmd(self):
+        # get it from the help
+        return [self.executable, "-h"]
+
+    def get_version(self):
+        version = super().get_version()
+
+        # The version is the 6th word in the 2nd line
+        version = version.splitlines()[1].split()[5]
+
+        return " ".join([self.name, version])

--- a/tools/runners/Slang.py
+++ b/tools/runners/Slang.py
@@ -14,3 +14,8 @@ class Slang(BaseRunner):
             self.cmd.append('-I' + incdir)
 
         self.cmd += params['files']
+
+    def get_version(self):
+        version = super().get_version()
+
+        return " ".join([self.name, version.split()[2]])

--- a/tools/runners/Sv2v_zachjs.py
+++ b/tools/runners/Sv2v_zachjs.py
@@ -14,3 +14,12 @@ class Sv2v_zachjs(BaseRunner):
             self.cmd.append('-I' + incdir)
 
         self.cmd += params['files']
+
+    def get_version(self):
+        version = super().get_version()
+
+        # sv2v stores the actual version at the second position
+        revision = version.split()[1]
+
+        # return it without the trailing comma
+        return " ".join([self.name, revision[:-1]])

--- a/tools/runners/Yosys.py
+++ b/tools/runners/Yosys.py
@@ -22,3 +22,11 @@ class Yosys(BaseRunner):
         with open(scr, 'w') as f:
             for svf in params['files']:
                 f.write('read_verilog -sv' + inc + ' ' + svf + '\n')
+
+    def get_version_cmd(self):
+        return [self.executable, "-V"]
+
+    def get_version(self):
+        version = super().get_version()
+
+        return " ".join([self.name, version.split()[1]])

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -388,6 +388,9 @@ if len(duplicates) > 0:
 
 try:
     for r in data:
+        with open(os.path.join(args.logs, r, "version")) as version_file:
+            data[r]["version"] = version_file.read()
+
         for tag in data[r]["tags"]:
             tag_handle = data[r]["tags"][tag]
 


### PR DESCRIPTION
This PR changes the structure of the runners. Instead of a single
script file, there are now directories with single script files.

The reason is that the directory will be used as the displayed name of
the runner (e.g. slang), but the script name will be used to determine
where does the actual tool binary come from (e.g. driver for slang).

This is needed to be able to find out whether the tool that is tested
comes from a submodule or is provided externally.

The tool is now versioned in two ways:
 * using the appropriate `--version` switch for the tool
 * if it comes from the submodule, using the commit hash from git

If any of the above is impossible `n/a` is shown instead of the version string/commit hash.

Because there is no standard `--version` switch for all the tools, the
runners as the wrappers have to now support this universal switches:
 * `--version` - to call the internal version getting switch of the tool
 * `--test TEST` - to run the actual test

This PR adds that to all the currently existing runners.

The version can be viewed in the tooltip in the report. The tooltip is displayed when hovering the tool names with a mouse, for example:
![2019-09-03-144443](https://user-images.githubusercontent.com/8438531/64174402-7ca35180-ce59-11e9-932f-4a237d63b07c.png)


Closes: #33