### PR TITLE
Differentiate between "should fail" and "tool broken"

### DIFF
--- a/tools/runner
+++ b/tools/runner
@@ -106,7 +106,7 @@ try:
     tool_should_fail = test_params["should_fail"] == "1"
     tool_failed = test_params["rc"] != 0
 
-    test_passed = tool_should_fail == tool_failed
+    test_passed = proc.returncode < 126 and tool_should_fail == tool_failed
 
     if test_passed:
         logger.info("PASS: {}/{}".format(args.runner, args.test))

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -148,7 +148,7 @@ for r in [os.path.dirname(r) for r in glob(args.logs + "/*/")]:
             tool_should_fail = test["should_fail"] == "1"
             tool_failed = test["rc"] != "0"
 
-            if tool_should_fail != tool_failed:
+            if int(test["rc"]) >= 126 or tool_should_fail != tool_failed:
                 passed = False
 
             status = "test-" + ("passed" if passed else "failed")


### PR DESCRIPTION
Use the exit codes to determine that.

Exit codes 126 and above are generally considered "abnormal" exit codes.
Use that convention here.

Ref: http://tldp.org/LDP/abs/html/exitcodes.html

Fixes #32.