### PR TITLE
enable the fixed header extension

### DIFF
--- a/conf/report-template.html
+++ b/conf/report-template.html
@@ -13,6 +13,8 @@
 
     <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.19/css/jquery.dataTables.css">
     <script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/1.10.19/js/jquery.dataTables.min.js"></script>
+    <script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/fixedheader/3.1.5/js/dataTables.fixedHeader.min.js"> </script>
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/fixedheader/3.1.5/css/fixedHeader.dataTables.min.css">
 
     <!-- custom sorting for the chapter IDs -->
     <script>
@@ -99,6 +101,7 @@
       $(document).ready( function () {
         $('#report_table').DataTable( {
           paging: false,
+          fixedHeader: true,
           "columnDefs": [ { "type": "sv-id", targets: 0 } ],
           "columns": [
             null,


### PR DESCRIPTION
This makes the header of the table stay on top of the page when
scrolling down.

Ref: https://datatables.net/extensions/fixedheader/
