### PR TITLE
Import tests from ivtest

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -55,3 +55,6 @@
 [submodule "third_party/cores/rsd"]
 	path = third_party/cores/rsd
 	url = https://github.com/rsd-devel/rsd
+[submodule "third_party/tests/ivtest"]
+	path = third_party/tests/ivtest
+	url = https://github.com/steveicarus/ivtest.git

--- a/conf/lrm.conf
+++ b/conf/lrm.conf
@@ -18,6 +18,7 @@ scr1	SCR1 RISC-V core
 taiga	Taiga RISC-V core
 blackparrot	BlackParrot RISC-V core
 rsd	RSD RISC-V core
+ivtest	Tests imported from ivtest
 5	Lexical conventions
 5.1	General
 5.2	Lexical tokens

--- a/generators/ivtest
+++ b/generators/ivtest
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+
+import re
+import os
+import sys
+import glob
+
+templ = """/*
+:name: {0}
+:description: Test imported from ivtest
+:files: {1}
+:should_fail: {2}
+:tags: ivtest
+*/
+"""
+
+try:
+    third_party_dir = os.environ['THIRD_PARTY_DIR']
+    tests_dir = os.environ['TESTS_DIR']
+    conf_dir = os.environ['CONF_DIR']
+except KeyError:
+    print("Export the THIRD_PARTY_DIR, TESTS_DIR and CONF_DIR variables first")
+    sys.exit(1)
+
+try:
+    tests_subdir = sys.argv[1]
+except IndexError:
+    print("Usage: ./generator <subdir>")
+    sys.exit(1)
+
+type_should_fail = ['CE', 'RE', 'EF', 'TE']
+
+ivtest_exclude = [
+    'regress-vams.list', 'regress-vhdl.list', 'vhdl_regress.list',
+    'vpi_regress.list'
+]
+
+ivtest_blacklist = [
+    'sv_casting',
+]
+
+ivtest_dir = os.path.abspath(os.path.join(third_party_dir, "tests", "ivtest"))
+ivtest_exclude = set(
+    map(lambda x: os.path.join(ivtest_dir, x), ivtest_exclude))
+ivtest_lists = list(
+    set(glob.glob(os.path.join(ivtest_dir, '*.list'))) - ivtest_exclude)
+
+tests = []
+
+skip = False
+
+for l in ivtest_lists:
+    with open(l, 'r') as f:
+        for line in f:
+            if skip:
+                skip = False
+                continue
+
+            # remove comments
+            line = re.sub(r'#.*?\n', '', line)
+
+            # skip multiline definitions
+            if re.search(r'\\\n', line):
+                skip = True
+                continue
+
+            line = line.split()
+
+            if len(line) < 3:
+                continue
+
+            name = line[0]
+            path = os.path.join(ivtest_dir, line[2], line[0] + '.v')
+            should_fail = 0
+
+            # sanitize name
+            name = re.sub(r'\W', '', name)
+
+            if name in ivtest_blacklist:
+                continue
+
+            for t in type_should_fail:
+                if re.match(t, line[1]):
+                    should_fail = 1
+
+            tests.append((name + '_iv', path, should_fail))
+
+test_dir = os.path.join(tests_dir, 'generated', tests_subdir)
+
+if not os.path.isdir(test_dir):
+    os.makedirs(test_dir, exist_ok=True)
+
+for test in tests:
+    test_file = os.path.join(test_dir, test[0] + '.sv')
+    with open(test_file, "w") as f:
+        f.write(templ.format(*test))

--- a/tools/BaseRunner.py
+++ b/tools/BaseRunner.py
@@ -186,7 +186,10 @@ class BaseRunner:
         regex = re.compile(r'module\s+(\w+)\s*[#(;]')
         for fn in params['files']:
             with open(fn) as f:
-                m = regex.search(f.read())
+                try:
+                    m = regex.search(f.read())
+                except UnicodeDecodeError:
+                    continue
                 if m:
                     return m.group(1)
         return None


### PR DESCRIPTION
This adds generator that imports most of the tests in `ivtest`

In it's current form it has several issues:
- It imports most of the tests but some should be omitted(VHDL integration, `Verilog-AMS`)
- Our `Makefile` can't handle that much tests in the `info` target and `@echo -e "Found the following tests:$(subst $(space),"\\n \* ", $(TESTS))\n"` had to be removed
- It makes the report page substantially slower, ie. switching between results of individual tests takes seconds
- `report.html` gets as big as 40MB which is too big to serve as a single static webpage and probably we should somehow load the results in a more dynamic way or at least store the logs in separate files

Closes #57 
Updated version depends on #117