### PR TITLE
Fix a couple of smallish typos in tests.

### DIFF
--- a/tests/chapter-8/8.26.6.3--diamond_relationship_parametrized.sv
+++ b/tests/chapter-8/8.26.6.3--diamond_relationship_parametrized.sv
@@ -5,7 +5,7 @@
 :tags: 8.26.6.3
 */
 module class_tb ();
-	interface class ibase#(type T = logic;
+	interface class ibase#(type T = logic);
 		pure virtual function void fn(T val);
 	endclass
 

--- a/tests/chapter-8/8.5--parameters.sv
+++ b/tests/chapter-8/8.5--parameters.sv
@@ -5,7 +5,7 @@
 :tags: 8.5 8.25
 */
 module class_tb ();
-	class test_cls $(parameter a = 12);
+	class test_cls #(parameter a = 12);
 	endclass
 
 	test_cls #(34) test_obj;


### PR DESCRIPTION
 - 8.26.6.3: diamond relationship will fail, but for the
   wrong reasons.
 - 8.5: parameter to class given with $ instead of #