### PR TITLE
Update 5.7.1--integers-left-padding.sv

### DIFF
--- a/tests/chapter-5/5.7.1--integers-left-padding.sv
+++ b/tests/chapter-5/5.7.1--integers-left-padding.sv
@@ -9,10 +9,10 @@ module top();
   logic [84:0] e, f, g;
 
   initial begin
-    a = 'h x;   // yields xxx
-    b = 'h 3x;  // yields 03x
-    c = 'h z3;  // yields zz3
-    d = 'h 0z3; // yields 0z3
+    a = 'hx;   // yields xxx
+    b = 'h3x;  // yields 03x
+    c = 'hz3;  // yields zz3
+    d = 'h0z3; // yields 0z3
     e = 'h5;    // yields {82{1'b0},3'b101}
     f = 'hx;    // yields {85{1'hx}}
     g = 'hz;    // yields {85{1'hz}}


### PR DESCRIPTION
Spaces are not allowed in between 'h and the digits in the LRM.