### PR TITLE
Update 12.6.3--conditional_pattern.sv

### DIFF
--- a/tests/chapter-12/12.6.3--conditional_pattern.sv
+++ b/tests/chapter-12/12.6.3--conditional_pattern.sv
@@ -23,6 +23,6 @@ module case_tb ();
 	bit [3:0] val;
 
 	initial begin
-		val = (tmp matches (tagged a '{4'b01zx, .v})) ? 1 : 2;
+		val = (tmp matches tagged a '{4'b01zx, .v}) ? 1 : 2;
 	end
 endmodule


### PR DESCRIPTION
LRM does not allow for () around the expression following matches, although it should.