### PR TITLE
Update 5.6.4--compiler-directives-define.sv

### DIFF
--- a/tests/chapter-5/5.6.4--compiler-directives-define.sv
+++ b/tests/chapter-5/5.6.4--compiler-directives-define.sv
@@ -9,7 +9,7 @@
 
 `ifdef XXX
 `undef XXX
-`elsif YYY == 1
+`elsif YYY 
 `define XXX 0
 `endif
 


### PR DESCRIPTION
I see no evidence in the LRM that expressions are supported for compiler directives, please correct me if I'm wrong