### PR TITLE
Reduce runner console log verbosity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ runners:
 # $(2) - test
 define runner_gen
 $(OUT_DIR)/logs/$(1)/$(2).log: $(TESTS_DIR)/$(2)
-	@./tools/runner --runner $(1) --test $(2) --out $(OUT_DIR)/logs/$(1)/$(2).log
+	@./tools/runner --runner $(1) --test $(2) --out $(OUT_DIR)/logs/$(1)/$(2).log --quiet
 
 tests: $(OUT_DIR)/logs/$(1)/$(2).log
 endef

--- a/tools/runner
+++ b/tools/runner
@@ -20,11 +20,14 @@ parser.add_argument("-t", "--test",
 parser.add_argument("-o", "--out",
                     required=True)
 
+parser.add_argument("-q", "--quiet", dest='verbosity', action='store_const',
+                    const=logging.ERROR, default=logging.DEBUG)
+
 args = parser.parse_args()
 
 # setup logger
 logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
+logger.setLevel(args.verbosity)
 
 ch = logging.StreamHandler()
 ch.setFormatter(logging.Formatter('%(levelname)-8s| %(message)s'))


### PR DESCRIPTION
Currently `tools/runner` was configured for `DEBUG` logging level but as suggested in #81 it should be reduced

Closes #81