### PR TITLE
Check if tool is installed before using it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ jobs:
         - "make zachjs-sv2v"
         - "make tree-sitter-verilog"
         - "make generate-tests"
-        - "make report"
+        - "make report USE_ALL_RUNNERS=1"
         - "mkdir out/deploy"
         - "cp out/report.html out/deploy/index.html"
         - "touch out/deploy/.nojekyll"

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ export TESTS_DIR
 export RUNNERS_DIR
 export GENERATORS_DIR
 
+USE_ALL_RUNNERS?=0
+
 include tools/runners.mk
 
 .PHONY: clean init info tests generate-tests report
@@ -47,9 +49,10 @@ generate-$(1):
 generate-tests: generate-$(1)
 endef
 
-RUNNERS := $(wildcard $(RUNNERS_DIR)/*.py)
-RUNNERS := $(RUNNERS:$(RUNNERS_DIR)/%=%)
-RUNNERS := $(basename $(RUNNERS))
+RUNNERS_FOUND := $(wildcard $(RUNNERS_DIR)/*.py)
+RUNNERS_FOUND := $(RUNNERS_FOUND:$(RUNNERS_DIR)/%=%)
+RUNNERS_FOUND := $(basename $(RUNNERS_FOUND))
+RUNNERS := $(shell OUT_DIR=$(OUT_DIR) ./tools/check-runners $(RUNNERS_FOUND))
 TESTS := $(shell find $(TESTS_DIR)/ -type f -iname *.sv)
 TESTS := $(TESTS:$(TESTS_DIR)/%=%)
 GENERATORS := $(wildcard $(GENERATORS_DIR)/*)
@@ -58,6 +61,11 @@ GENERATORS := $(GENERATORS:$(GENERATORS_DIR)/%=%)
 space := $(subst ,, )
 
 info:
+ifneq ($(USE_ALL_RUNNERS), 0)
+ifneq ($(RUNNERS), $(RUNNERS_FOUND))
+	$(error Some runners are missing)
+endif
+endif
 	@echo -e "Found the following runners:$(subst $(space),"\\n \* ", $(RUNNERS))\n"
 	@echo -e "Found the following tests:$(subst $(space),"\\n \* ", $(TESTS))\n"
 

--- a/tools/BaseRunner.py
+++ b/tools/BaseRunner.py
@@ -1,4 +1,5 @@
 import subprocess
+import shutil
 
 
 class BaseRunner:
@@ -13,8 +14,15 @@ class BaseRunner:
     to be detected and launched by the Makefile.
     """
 
-    def __init__(self, name):
+    def __init__(self, name, executable=None):
+        """Base runner class constructor
+        Arguments:
+        name -- runner name.
+        executable -- name of an executable used by the particular runner
+        can be omitted if default can_run method isn't used.
+        """
         self.name = name
+        self.executable = executable
 
     def run(self, tmp_dir, params):
         """Run the provided test case
@@ -36,3 +44,13 @@ class BaseRunner:
         log, _ = proc.communicate()
 
         return (log.decode('utf-8'), proc.returncode)
+
+    def can_run(self):
+        """Check if runner can be used
+        This method is called by the main runner script (tools/runner) as
+        a sanity check to verify that tool used by the runner is properly
+        installed.
+
+        Returns True when tool is installed and can be used, False otherwise.
+        """
+        return shutil.which(self.executable) is not None

--- a/tools/BaseRunner.py
+++ b/tools/BaseRunner.py
@@ -1,30 +1,32 @@
 import subprocess
 
-##
-# This is the common base class shared by all runners.
-#
-# Each runner must either implement prepare_run_cb
-# or override the run method.
-#
-# prepare_run_cb is responsible for generating command to run
-# and preparing the command working directory if required by the tool.
-#
-# Runners must be located in tools/runners subdirectory
-# to be detected and launched by the Makefile.
-##
-
 
 class BaseRunner:
+    """Common base class shared by all runners
+    Each runner must either implement prepare_run_cb
+    or override the run method.
+
+    prepare_run_cb is responsible for generating command to run
+    and preparing the command working directory if required by the tool.
+
+    Runners must be located in tools/runners subdirectory
+    to be detected and launched by the Makefile.
+    """
+
     def __init__(self, name):
         self.name = name
 
-##
-# This method is called by the main runner script (tools/runner).
-# @param tmp_dir is a temporary directory created for this test run.
-# @param params is a dictionary with all metadata from the test file.
-#     All keys are stripped of their colons, ie. :tags: becomes tags.
-# @return A tuple containing command execution log and return code.
     def run(self, tmp_dir, params):
+        """Run the provided test case
+        This method is called by the main runner script (tools/runner).
+
+        Arguments:
+        tmp_dir -- temporary directory created for this test run.
+        params -- dictionary with all metadata from the test file.
+                  All keys are used without colons, ie. :tags: becomes tags.
+
+        Returns a tuple containing command execution log and return code.
+        """
         self.prepare_run_cb(tmp_dir, params)
 
         proc = subprocess.Popen(self.cmd, cwd=tmp_dir,

--- a/tools/check-runners
+++ b/tools/check-runners
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import argparse
+from importlib import import_module
+
+parser = argparse.ArgumentParser()
+
+parser.add_argument("runners", metavar='runner',
+                    type=str, nargs='+')
+
+args = parser.parse_args()
+
+runner_obj = None
+
+runners_ok = []
+
+for runner in args.runners:
+    try:
+        module = import_module('runners.' + runner)
+        runner_cls = getattr(module, runner)
+        runner_obj = runner_cls()
+    except Exception:
+        continue
+
+    new_path = [os.path.abspath(os.environ['OUT_DIR'] + "/runners/bin/"),
+                os.environ['PATH']]
+
+    os.environ['PATH'] = ":".join(new_path)
+
+    if runner_obj.can_run():
+        print(runner)
+    else:
+        print('Runner {} not found'.format(runner), file=sys.stderr)

--- a/tools/runners/Icarus.py
+++ b/tools/runners/Icarus.py
@@ -3,10 +3,10 @@ from BaseRunner import BaseRunner
 
 class Icarus(BaseRunner):
     def __init__(self):
-        super().__init__("icarus")
+        super().__init__("icarus", "iverilog")
 
     def prepare_run_cb(self, tmp_dir, params):
-        self.cmd = ['iverilog', '-g2012', '-o iverilog.out']
+        self.cmd = [self.executable, '-g2012', '-o iverilog.out']
 
         for incdir in params['incdirs']:
             self.cmd.append('-I' + incdir)

--- a/tools/runners/Odin.py
+++ b/tools/runners/Odin.py
@@ -3,11 +3,11 @@ from BaseRunner import BaseRunner
 
 class Odin(BaseRunner):
     def __init__(self):
-        super().__init__("odin")
+        super().__init__("odin", "odin_II")
 
     def prepare_run_cb(self, tmp_dir, params):
 
-        self.cmd = ['odin_II', '--permissive', '-o odin.blif', '-V']
+        self.cmd = [self.executable, '--permissive', '-o odin.blif', '-V']
 
         # odin doesn't seem to support include directories
         # and thus only list of files is provided to it

--- a/tools/runners/Slang.py
+++ b/tools/runners/Slang.py
@@ -3,10 +3,10 @@ from BaseRunner import BaseRunner
 
 class Slang(BaseRunner):
     def __init__(self):
-        super().__init__("slang")
+        super().__init__("slang", "driver")
 
     def prepare_run_cb(self, tmp_dir, params):
-        self.cmd = ['driver']
+        self.cmd = [self.executable]
 
         for incdir in params['incdirs']:
             self.cmd.append('-I' + incdir)

--- a/tools/runners/Sv2v_zachjs.py
+++ b/tools/runners/Sv2v_zachjs.py
@@ -3,10 +3,10 @@ from BaseRunner import BaseRunner
 
 class Sv2v_zachjs(BaseRunner):
     def __init__(self):
-        super().__init__("zachjs-sv2v")
+        super().__init__("zachjs-sv2v", "zachjs-sv2v")
 
     def prepare_run_cb(self, tmp_dir, params):
-        self.cmd = ['zachjs-sv2v']
+        self.cmd = [self.executable]
 
         for incdir in params['incdirs']:
             self.cmd.append('-i' + incdir)

--- a/tools/runners/Verilator.py
+++ b/tools/runners/Verilator.py
@@ -5,13 +5,13 @@ from BaseRunner import BaseRunner
 
 class Verilator(BaseRunner):
     def __init__(self):
-        super().__init__("verilator")
+        super().__init__("verilator", "verilator")
 
     def prepare_run_cb(self, tmp_dir, params):
         scr = os.path.join(tmp_dir, 'scr.sh')
 
         with open(scr, 'w') as f:
-            f.write('verilator $@\n')
+            f.write('{0} $@\n'.format(self.executable))
 
         # verilator executable is a script but it doesn't
         # have shell shebang on the first line

--- a/tools/runners/Yosys.py
+++ b/tools/runners/Yosys.py
@@ -5,12 +5,12 @@ from BaseRunner import BaseRunner
 
 class Yosys(BaseRunner):
     def __init__(self):
-        super().__init__("yosys")
+        super().__init__("yosys", "yosys")
 
     def prepare_run_cb(self, tmp_dir, params):
         scr = os.path.join(tmp_dir, 'scr.ys')
 
-        self.cmd = ['yosys', '-Q', '-T', 'scr.ys']
+        self.cmd = [self.executable, '-Q', '-T', 'scr.ys']
 
         inc = ""
 

--- a/tools/runners/tree_sitter_verilog.py
+++ b/tools/runners/tree_sitter_verilog.py
@@ -44,3 +44,12 @@ class tree_sitter_verilog(BaseRunner):
                     self.ret = 1
 
         return (self.log, self.ret)
+
+    def can_run(self):
+        try:
+            return os.path.isfile(os.path.abspath(os.path.join(
+                                  os.environ['OUT_DIR'], 'runners',
+                                  'lib', 'verilog.so')))
+        except KeyError as e:
+            print(str(e))
+            return False


### PR DESCRIPTION
Currently all tools are used without checking if a particular tool is installed, in #83 it was suggested to test if tools are present before using them and this adds support for checking that.
If tool is not present then testing it will be skipped and it won't be included in the report.

Closes #83