### PR TITLE
Wrong assignment_pattern form when using "default"

### DIFF
--- a/tests/chapter-5/5.10-structures.sv
+++ b/tests/chapter-5/5.10-structures.sv
@@ -15,7 +15,7 @@ module top();
   initial begin;
     ms = '{ 0, 1};
 
-    ms = '{ default, 1};
+    ms = '{ default:1, int:1};
 
     ms = '{ int:0, int:1};
   end;

--- a/tests/chapter-5/5.10-structures.sv
+++ b/tests/chapter-5/5.10-structures.sv
@@ -18,6 +18,6 @@ module top();
     ms = '{ default:1, int:1};
 
     ms = '{ int:0, int:1};
-  end;
+  end
 
 endmodule


### PR DESCRIPTION
Wrong assignment_pattern form when using "default" 
No semi-column allowed after begin or end keywords