### PR TITLE
Update 12.6.2--if_pattern.sv

### DIFF
--- a/tests/chapter-12/12.6.2--if_pattern.sv
+++ b/tests/chapter-12/12.6.2--if_pattern.sv
@@ -20,7 +20,7 @@ module case_tb ();
 
 	u tmp;
 
-	initial if (tmp matches (tagged a '{4'b01zx, .v}))
+	initial if (tmp matches tagged a '{4'b01zx, .v})
 		$display("a %d", v);
 		
 		


### PR DESCRIPTION
LRM does not allow () around the expression following "matches", although it should, but if we want to be strict, we should not allow it

Signed-off-by: Alain Dargelas <alainmarcel@yahoo.com>