### PR TITLE
Import tests from hdlConvertor

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,3 +28,6 @@
 [submodule "third_party/cores/fx68k"]
 	path = third_party/cores/fx68k
 	url = https://github.com/ijor/fx68k
+[submodule "third_party/tests/hdlconvertor"]
+	path = third_party/tests/hdlconvertor
+	url = https://github.com/Nic30/hdlConvertor

--- a/conf/generators/meta-path/hdlconvertor.json
+++ b/conf/generators/meta-path/hdlconvertor.json
@@ -1,0 +1,9 @@
+{
+	"name": "hdlconvertor",
+	"project": "hdlconv",
+	"should_fail": "0",
+	"paths": [
+		["tests", "hdlconvertor", "tests", "sv_test", "*"]
+	],
+	"matches": ["*.sv"]
+}

--- a/conf/lrm.conf
+++ b/conf/lrm.conf
@@ -9,6 +9,7 @@ swerv	SweRV RISC-V core
 ibex	Ibex RISC-V core
 fx68k	FX68K m68k core
 yosys	Tests imported from Yosys
+hdlconv	Tests imported from hdlConvertor
 5	Lexical conventions
 5.1	General
 5.2	Lexical tokens


### PR DESCRIPTION
Depends on #117

Slang seems to have issues with those tests on my PC, it uses up all the available RAM and swap on some of the cases, for example `tests/sv_test/std2017/p550.sv`. I wonder how this will behave in travis CI.