### PR TITLE
[Obsolete, see #147] Not using silent rules; improve runner compilation parallelism

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,8 @@ include tools/runners.mk
 .PHONY: clean init info tests generate-tests report
 
 clean:
-	@echo -e "Removing $(OUT_DIR)"
-	@rm -rf $(OUT_DIR)
-	@echo -e "Removing $(TESTS_DIR)/generated/"
-	@rm -rf $(TESTS_DIR)/generated/
+	rm -rf $(OUT_DIR)
+	rm -rf $(TESTS_DIR)/generated/
 
 init:
 ifneq (,$(wildcard $(OUT_DIR)/*))
@@ -35,7 +33,7 @@ runners:
 # $(2) - test
 define runner_gen
 $(OUT_DIR)/logs/$(1)/$(2).log: $(TESTS_DIR)/$(2)
-	@./tools/runner --runner $(1) --test $(2) --out $(OUT_DIR)/logs/$(1)/$(2).log --quiet
+	./tools/runner --runner $(1) --test $(2) --out $(OUT_DIR)/logs/$(1)/$(2).log --quiet
 
 tests: $(OUT_DIR)/logs/$(1)/$(2).log
 endef
@@ -65,10 +63,8 @@ tests:
 
 generate-tests:
 
-report: init info tests
-	@echo -e "\nGenerating report"
-	@./tools/sv-report
-	@echo -e "\nDONE!"
+report: init tests
+	./tools/sv-report
 
 $(foreach g, $(GENERATORS), $(eval $(call generator_gen,$(g))))
 $(foreach r, $(RUNNERS),$(foreach t, $(TESTS),$(eval $(call runner_gen,$(r),$(t)))))

--- a/tools/runners.mk
+++ b/tools/runners.mk
@@ -11,62 +11,59 @@ runners:
 odin: $(INSTALL_DIR)/bin/odin_II
 
 $(INSTALL_DIR)/bin/odin_II:
-	@mkdir -p $(OUT_DIR)/runners/bin
-	@$(MAKE) -C $(RDIR)/odin_ii/ODIN_II/ build
-	@cp $(RDIR)/odin_ii/ODIN_II/odin_II $(INSTALL_DIR)/bin/
+	$(MAKE) -C $(RDIR)/odin_ii/ODIN_II/ build
+	install -D $(RDIR)/odin_ii/ODIN_II/odin_II $@
 
 # yosys
 yosys: $(INSTALL_DIR)/bin/yosys
 
 $(INSTALL_DIR)/bin/yosys:
-	@mkdir -p $(OUT_DIR)/runners/bin
-	@$(MAKE) -C $(RDIR)/yosys ENABLE_TCL=0 ENABLE_ABC=0 ENABLE_GLOB=0 ENABLE_PLUGINS=0 ENABLE_READLINE=0 ENABLE_COVER=0
-	@cp $(RDIR)/yosys/yosys $(INSTALL_DIR)/bin/
+	$(MAKE) -C $(RDIR)/yosys ENABLE_TCL=0 ENABLE_ABC=0 ENABLE_GLOB=0 ENABLE_PLUGINS=0 ENABLE_READLINE=0 ENABLE_COVER=0
+	install -D $(RDIR)/yosys/yosys $@
 
 # icarus
 icarus: $(INSTALL_DIR)/bin/iverilog
 
 $(INSTALL_DIR)/bin/iverilog:
-	@mkdir -p $(OUT_DIR)/runners/bin
-	@cd $(RDIR)/icarus && autoconf
-	@cd $(RDIR)/icarus && ./configure --prefix=$(abspath $(INSTALL_DIR))/
-	@$(MAKE) -C $(RDIR)/icarus
-	@$(MAKE) -C $(RDIR)/icarus installdirs
-	@$(MAKE) -C $(RDIR)/icarus install
+	cd $(RDIR)/icarus && autoconf
+	cd $(RDIR)/icarus && ./configure --prefix=$(abspath $(INSTALL_DIR))/
+	$(MAKE) -C $(RDIR)/icarus
+	$(MAKE) -C $(RDIR)/icarus installdirs
+	$(MAKE) -C $(RDIR)/icarus install
 
 # verilator
 verilator: $(INSTALL_DIR)/bin/verilator
 
 $(INSTALL_DIR)/bin/verilator:
-	@mkdir -p $(OUT_DIR)/runners/bin
-	@cd $(RDIR)/verilator && autoconf
-	@cd $(RDIR)/verilator && ./configure --prefix=$(abspath $(INSTALL_DIR))/
-	@$(MAKE) -C $(RDIR)/verilator
-	@$(MAKE) -C $(RDIR)/verilator install
+	cd $(RDIR)/verilator && autoconf
+	cd $(RDIR)/verilator && ./configure --prefix=$(abspath $(INSTALL_DIR))/
+	$(MAKE) -C $(RDIR)/verilator
+	$(MAKE) -C $(RDIR)/verilator install
 
 # slang
 slang: $(INSTALL_DIR)/bin/driver
 
 $(INSTALL_DIR)/bin/driver:
-	@mkdir -p $(OUT_DIR)/runners/bin
-	@mkdir -p $(RDIR)/slang/build
-	@cd $(RDIR)/slang/build && cmake .. -DSLANG_INCLUDE_TESTS=OFF && make -j13
-	@cp $(RDIR)/slang/build/bin/* $(INSTALL_DIR)/bin/
+	mkdir -p $(RDIR)/slang/build
+	cd $(RDIR)/slang/build && cmake .. -DSLANG_INCLUDE_TESTS=OFF
+	$(MAKE) -C $(RDIR)/slang/build
+	mkdir -p $(INSTALL_DIR)/bin
+	install $(RDIR)/slang/build/bin/* $(INSTALL_DIR)/bin/
 
 # zachjs-sv2v
 zachjs-sv2v: $(INSTALL_DIR)/bin/zachjs-sv2v
 
 $(INSTALL_DIR)/bin/zachjs-sv2v:
-	@mkdir -p $(OUT_DIR)/runners/bin
-	@cd $(RDIR)/zachjs-sv2v && make
-	@cp $(RDIR)/zachjs-sv2v/bin/sv2v $@
+	$(MAKE) -C $(RDIR)/zachjs-sv2v
+	install -D $(RDIR)/zachjs-sv2v/bin/sv2v $@
 
 # tree-sitter-verilog
 tree-sitter-verilog: $(INSTALL_DIR)/lib/verilog.so
 
 $(INSTALL_DIR)/lib/verilog.so:
-	@cd $(RDIR)/tree-sitter-verilog && npm install
-	@/usr/bin/env python3 -c "from tree_sitter import Language; Language.build_library(\"$@\", [\"$(abspath $(RDIR)/tree-sitter-verilog)\"])"
+	mkdir -p $(INSTALL_DIR)/lib
+	cd $(RDIR)/tree-sitter-verilog && npm install
+	/usr/bin/env python3 -c "from tree_sitter import Language; Language.build_library(\"$@\", [\"$(abspath $(RDIR)/tree-sitter-verilog)\"])"
 
 # setup the dependencies
 RUNNERS_TARGETS := odin yosys icarus verilator slang zachjs-sv2v tree-sitter-verilog


### PR DESCRIPTION
 * The silent rules made it hard to follow what is going on.
 * If we use `$(MAKE)` directly in a rule, it is able to inherit
   other configuration from the inherited make, such as -j; this
   makes compilation much faster in these cases.
  * Instead of `cp`, use `install` to install binaries
     * It prevents issues when the binary is in use at the time
          for some reason.
      * With -D, we can make sure that directories are created, so
          no need for our own `mkdir -p`
    
Fixes #80