### PR TITLE
Let the browser decide best font-size for report cells.

### DIFF
--- a/conf/report/report.css
+++ b/conf/report/report.css
@@ -39,7 +39,6 @@ table.dataTable tbody tr th#report_table_info {
   cursor: pointer;
 
   font-family: "Courier New", Courier, monospace;
-  font-size: 10px;
   font-weight: normal;
 }
 


### PR DESCRIPTION
The fixed 10px font is hardly readable on high-res screens. Without
fixing the size, we can have the browser choose the best-looking
version.

Signed-off-by: Henner Zeller <h.zeller@acm.org>