### PR TITLE
report: add syntax highlighting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ generate-tests:
 report: init info tests
 	./tools/sv-report
 	cp ./conf/report/report.* ./out/.
-	cp -rfT ./tests ./out/tests/
+	find $(TESTS_DIR) -name *.sv -exec ./tools/formatter $(OUT_DIR) {} +
 
 $(foreach g, $(GENERATORS), $(eval $(call generator_gen,$(g))))
 $(foreach r, $(RUNNERS),$(foreach t, $(TESTS),$(eval $(call runner_gen,$(r),$(t)))))

--- a/conf/requirements.txt
+++ b/conf/requirements.txt
@@ -2,3 +2,4 @@ conan
 flake8
 jinja2
 tree_sitter
+pygments

--- a/tools/formatter
+++ b/tools/formatter
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+import os
+import argparse
+from pygments import lexers, highlight
+from pygments.formatters import HtmlFormatter
+
+parser = argparse.ArgumentParser()
+
+parser.add_argument("outdir")
+
+parser.add_argument("files", metavar='file',
+                    type=str, nargs='+')
+
+args = parser.parse_args()
+
+lex = lexers.get_lexer_by_name("systemverilog")
+formatter = HtmlFormatter(full=True, linenos=True)
+
+for fname in args.files:
+    with open(fname, 'rb') as f:
+        code = f.read()
+        path = os.path.join(args.outdir, fname + '.html')
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, 'w') as out:
+            highlight(code, lex, formatter, outfile=out)

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -61,7 +61,7 @@ def logToHTML(path):
     depth = path.count('/') - 1
     link_pat = r'[^ ]*/(tests/[^ ]+\.sv)'
     src_relative = '../' * depth
-    link_sub = r'<a href="{}\1" target="file-frame">\1</a>'
+    link_sub = r'<a href="{}\1.html" target="file-frame">\1</a>'
     with open(path, 'r') as log:
         with open(path + '.html', 'w') as html:
             html.write('<pre>')


### PR DESCRIPTION
This fixes #162 and adds syntax highlighting using [pygments](http://pygments.org/).
Syntax highlighted sources look like this:
![Screenshot_20190926_085418](https://user-images.githubusercontent.com/45362851/65665684-6a719900-e03c-11e9-9657-50181ebee855.png)
