### PR TITLE
Add __pycache__ dirs to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 out
 tests/generated
+__pycache__


### PR DESCRIPTION
These seem to appear in several places when generating the report.