### PR TITLE
report: restore current cell highlighting

### DIFF
--- a/conf/report/report.css
+++ b/conf/report/report.css
@@ -48,7 +48,8 @@ table.dataTable tfoot th {
 }
 
 .test-cell-selected {
-  border: 2px solid black;
+  border: 1px solid black;
+  filter: brightness(95%);
   font-weight: bold;
 }
 

--- a/conf/report/report.js
+++ b/conf/report/report.js
@@ -99,6 +99,9 @@ function toggleLog(div_id, cell_id) {
   } else {
     outer_div.classList.remove("logfile-outer-shown");
   }
+
+  cell = document.getElementById(cell_id);
+  cell.classList.toggle("test-cell-selected");
 }
 
 function hideLog(div_id) {


### PR DESCRIPTION
Make the currently selected cell highlighted.

This was already implemented earlier, but seems to have been removed by accident in #117.

Some style adjustments were needed to make it work/look good after changes in #163

Example of a selected cell:

![2019-09-26-160528](https://user-images.githubusercontent.com/8438531/65695037-1506ad80-e077-11e9-8953-dc757f553c44.png)
