### PR TITLE
Use anaconda packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,6 @@ python:
 
 cache:
   pip: true
-  ccache: true
-  directories:
-    - $HOME/.ccache
-    - $HOME/.stack
-    - $HOME/.conan
 
 env:
   global:
@@ -28,31 +23,18 @@ jobs:
 
     - name: "Generate report.hml"
       install:
-        - sudo apt-get install gperf -y
-        - sudo apt-get install libfl-dev -y
-        - sudo apt-get install npm
-        - sudo apt-get install gcc-8 -y
-        - sudo apt-get install g++-8 -y
-        - sudo apt-get install yosys -y
-        - sudo apt-get install iverilog -y
-        - sudo apt-get install verilator -y
-        - sudo ln -sf /usr/bin/gcc-8 /usr/bin/gcc
-        - sudo ln -sf /usr/bin/g++-8 /usr/bin/g++
-        - sudo ln -sf /usr/bin/ccache /usr/local/bin/gcc
-        - sudo ln -sf /usr/bin/ccache /usr/local/bin/g++
-        - sudo ln -sf /usr/bin/ccache /usr/local/bin/gcc-8
-        - sudo ln -sf /usr/bin/ccache /usr/local/bin/g++-8
+        - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+        - bash miniconda.sh -b -p $HOME/miniconda
+        - source "$HOME/miniconda/etc/profile.d/conda.sh"
+        - hash -r
+        - conda config --set always_yes yes --set changeps1 no
+        - conda install -q setuptools
+        - conda update -q conda
+        - conda info -a
+        - conda env create --file conf/environment.yml
+        - conda activate sv-test-env
         - pip install -r conf/requirements.txt
-        - mkdir -p ~/.local/bin
-        - export PATH=$HOME/.local/bin:$PATH
-        - travis_retry curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
-        - curl https://sh.rustup.rs -sSf | sh -s -- -y
-        - source $HOME/.cargo/env
       script:
-        - "make slang"
-        - "make odin"
-        - "make zachjs-sv2v"
-        - "make tree-sitter-verilog"
         - "make sv-parser"
         - "make generate-tests"
         - "make report USE_ALL_RUNNERS=1"

--- a/conf/environment.yml
+++ b/conf/environment.yml
@@ -1,0 +1,13 @@
+name: sv-test-env
+channels:
+  - symbiflow
+  - pkgw-forge
+  - conda-forge
+dependencies:
+  - verilator
+  - yosys
+  - iverilog
+  - zachjs-sv2v
+  - odin_ii
+  - tree-sitter-verilog
+  - slang

--- a/conf/requirements.txt
+++ b/conf/requirements.txt
@@ -1,4 +1,4 @@
-conan
+pyyaml
 jinja2
 tree_sitter
 pygments

--- a/tools/runners.mk
+++ b/tools/runners.mk
@@ -41,14 +41,13 @@ $(INSTALL_DIR)/bin/verilator:
 	$(MAKE) -C $(RDIR)/verilator install
 
 # slang
-slang: $(INSTALL_DIR)/bin/driver
+slang: $(INSTALL_DIR)/bin/slang-driver
 
-$(INSTALL_DIR)/bin/driver:
+$(INSTALL_DIR)/bin/slang-driver:
 	mkdir -p $(RDIR)/slang/build
 	cd $(RDIR)/slang/build && cmake .. -DSLANG_INCLUDE_TESTS=OFF
 	$(MAKE) -C $(RDIR)/slang/build
-	mkdir -p $(INSTALL_DIR)/bin
-	install $(RDIR)/slang/build/bin/* $(INSTALL_DIR)/bin/
+	install -D $(RDIR)/slang/build/bin/driver $@
 
 # zachjs-sv2v
 zachjs-sv2v: $(INSTALL_DIR)/bin/zachjs-sv2v

--- a/tools/runners.mk
+++ b/tools/runners.mk
@@ -58,9 +58,9 @@ $(INSTALL_DIR)/bin/zachjs-sv2v:
 	install -D $(RDIR)/zachjs-sv2v/bin/sv2v $@
 
 # tree-sitter-verilog
-tree-sitter-verilog: $(INSTALL_DIR)/lib/verilog.so
+tree-sitter-verilog: $(INSTALL_DIR)/lib/tree-sitter-verilog.so
 
-$(INSTALL_DIR)/lib/verilog.so:
+$(INSTALL_DIR)/lib/tree-sitter-verilog.so:
 	mkdir -p $(INSTALL_DIR)/lib
 	cd $(RDIR)/tree-sitter-verilog && npm install
 	/usr/bin/env python3 -c "from tree_sitter import Language; Language.build_library(\"$@\", [\"$(abspath $(RDIR)/tree-sitter-verilog)\"])"

--- a/tools/runners/Slang.py
+++ b/tools/runners/Slang.py
@@ -3,7 +3,7 @@ from BaseRunner import BaseRunner
 
 class Slang(BaseRunner):
     def __init__(self):
-        super().__init__("slang", "driver")
+        super().__init__("slang", "slang-driver")
 
         self.url = "https://github.com/MikePopoloski/slang"
 


### PR DESCRIPTION
This PR aims to replace current mix of locally built tools and system packages used in CI with packages downloaded from SymbiFlow conda [repository](https://anaconda.org/SymbiFlow/repo)
To achieve that, all tools we test should be available from that repo
Current tool status:
- [x] Verilator
- [x] Yosys - might require different package created from upstream sources
- [x] Icarus Verilog
- [x] Odin - SymbiFlow/conda-packages#40
- [x] Slang - SymbiFlow/conda-packages#43 SymbiFlow/conda-packages#48
- [x] sv2v(zachjs) - SymbiFlow/conda-packages#39
- [x] tree-sitter-verilog - SymbiFlow/conda-packages#41

Closes #54