### PR TITLE
Automatically open the first file from the log

### DIFF
--- a/conf/report/report-template.html
+++ b/conf/report/report-template.html
@@ -56,8 +56,8 @@
          id="{{ tool }}-{{ tag }}-logfile">
       <div class="logtab-bar"
            id="logtab-{{tool}}-{{tag}}-bar">
-	      <button class="logtab-btn logtab-close-btn"
-		      onclick='toggleLog("{{tool}}", "{{tag}}", null)'>
+        <button class="logtab-btn logtab-close-btn"
+                onclick='toggleLog("{{tool}}", "{{tag}}", null, null)'>
           close
         </button>
         {% for test, output in tooldata["tags"][tag]["logs"].items() %}
@@ -66,9 +66,10 @@
                        {{output["status"]}}
                        "
                 onclick='selectTab("{{output["fname"]}}",
-                                   "logtab-btn-{{tool}}-{{tag}}-{{test}}")'
+                                   "logtab-btn-{{tool}}-{{tag}}-{{test}}",
+                                   "{{output["first_file"]}}")',
                 id="logtab-btn-{{tool}}-{{tag}}-{{test}}"
-          >
+                >
           {{ output["name"] }}
         </button>
         {% endfor %}
@@ -100,7 +101,8 @@
             {% if "test-na" not in tooldata["tags"][tag]["status"] %}
             id='{{tool}}-{{tag}}-cell'
             onclick='toggleLog("{{tool}}", "{{tag}}",
-                               "{{tooldata["tags"][tag]["logs"]|first}}")'
+                               "{{tooldata["tags"][tag]["logs"]|first}}",
+                               "{{tooldata["tags"][tag]["logs"][tooldata["tags"][tag]["logs"]|first]["first_file"]}}")'
             {% endif %}
             >
             {% if "test-na" not in tooldata["tags"][tag]["status"] %}

--- a/conf/report/report.js
+++ b/conf/report/report.js
@@ -74,7 +74,7 @@ $.fn.dataTable.ext.order['test-status'] = function ( settings, col ) {
   });
 };
 
-function toggleLog(tool, tag, test_id) {
+function toggleLog(tool, tag, test_id, file) {
   all_logs = document.getElementsByClassName("logfile-shown");
 
   var div_id = [tool, tag, "logfile"].join("-");
@@ -93,9 +93,9 @@ function toggleLog(tool, tag, test_id) {
     window.open('about:blank', 'log-frame')
   } else {
     selectTab("logs/" + test_id + ".html",
-              ["logtab-btn", tool, tag, test_id].join("-"));
+              ["logtab-btn", tool, tag, test_id].join("-"),
+              file);
   }
-  window.open('about:blank', 'file-frame')
 
   if (log_div.classList.toggle("logfile-shown")) {
     outer_div.classList.add("logfile-outer-shown");
@@ -117,7 +117,7 @@ function hideLog(div_id) {
   }
 }
 
-function selectTab(path, btn_id) {
+function selectTab(path, btn_id, file) {
   all_btns = document.getElementsByClassName("logtab-btn-selected");
   for (var i=0; i < all_btns.length; i++) {
     all_btns[i].classList.remove("logtab-btn-selected");
@@ -126,8 +126,13 @@ function selectTab(path, btn_id) {
   btn = document.getElementById(btn_id);
   btn.classList.add("logtab-btn-selected");
 
-  window.open('about:blank', 'file-frame')
   window.open(path, "log-frame");
+
+  if (file === null) {
+    window.open("about:blank", 'file-frame')
+  } else {
+    window.open(file, 'file-frame')
+  }
 }
 
 $(function() {

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -63,11 +63,20 @@ def logToHTML(path):
     src_relative = '../' * depth
     link_sub = r'<a href="{}\1.html" target="file-frame">\1</a>'
     with open(path, 'r') as log:
+        try:
+            first_file = re.findall(link_pat, log.read())[0] + ".html"
+        except IndexError:
+            first_file = "about:blank"
+
+        log.seek(0)
+
         with open(path + '.html', 'w') as html:
             html.write('<pre>')
             for l in log:
                 html.write(re.sub(link_pat, link_sub.format(src_relative), l))
             html.write('</pre>')
+
+    return first_file
 
 
 # generate input database first
@@ -149,7 +158,7 @@ for r in [os.path.dirname(r) for r in glob(args.logs + "/*/")]:
             f.seek(0)
             tests[t_id]["log"] = f.read()
             tests[t_id]["fname"] = os.path.join('logs', t_id + '.html')
-            logToHTML(t)
+            tests[t_id]["first_file"] = logToHTML(t)
 
         # check if test was skipped
         if t_id not in tests:
@@ -226,6 +235,7 @@ try:
                     inner["status"] = test_handle["status"]
                     inner["name"] = test_handle["name"]
                     inner["fname"] = test_handle["fname"]
+                    inner["first_file"] = test_handle["first_file"]
         data[r]["total"] = {}
 
         # find the number of tests that passed


### PR DESCRIPTION
Look for the very first file in the `files` parameter in the tests, and open it in the designated pane after opening the tab.