### PR TITLE
'vectored' does not apply to type 'logic'

### DIFF
--- a/tests/chapter-6/6.9.2--vector_scalared.sv
+++ b/tests/chapter-6/6.9.2--vector_scalared.sv
@@ -5,7 +5,6 @@
 :tags: 6.9.2
 */
 module top();
-	logic scalared [15:0] a = 0;
+	tri1 scalared [15:0] a = 0;
 
-	a[1] = 1;
 endmodule

--- a/tests/chapter-6/6.9.2--vector_vectored.sv
+++ b/tests/chapter-6/6.9.2--vector_vectored.sv
@@ -5,7 +5,6 @@
 :tags: 6.9.2
 */
 module top();
-	logic vectored [15:0] a;
+	tri1 vectored [15:0] a;
 
-	a = 12;
 endmodule


### PR DESCRIPTION
Signed-off-by: Alain Dargelas <alainmarcel@yahoo.com>