### PR TITLE
runners: add the -i switch to icarus invocation

### DIFF
--- a/tools/runners/Icarus.py
+++ b/tools/runners/Icarus.py
@@ -6,7 +6,7 @@ class Icarus(BaseRunner):
         super().__init__("icarus", "iverilog")
 
     def prepare_run_cb(self, tmp_dir, params):
-        self.cmd = [self.executable, '-g2012', '-o iverilog.out']
+        self.cmd = [self.executable, '-i', '-g2012', '-o iverilog.out']
 
         for incdir in params['incdirs']:
             self.cmd.append('-I' + incdir)


### PR DESCRIPTION
This should make it pass several tests according to: #138 

Depends on #193 (to pull in the latest changes regarding the `-i` switch).