### PR TITLE
Custom pygments styles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,8 @@ generate-tests:
 
 report: init info tests
 	./tools/sv-report
-	cp ./conf/report/report.* ./out/.
+	cp ./conf/report/*.css ./out/.
+	cp ./conf/report/*.js ./out/.
 
 $(foreach g, $(GENERATORS), $(eval $(call generator_gen,$(g))))
 $(foreach r, $(RUNNERS),$(foreach t, $(TESTS),$(eval $(call runner_gen,$(r),$(t)))))

--- a/conf/report/code-template.html
+++ b/conf/report/code-template.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="stylesheet" type="text/css" href="{{ csspath }}">
+  </head>
+  <body>
+    {{ code }}
+  </body>
+</html>

--- a/conf/report/code-template.html
+++ b/conf/report/code-template.html
@@ -5,6 +5,7 @@
     <link rel="stylesheet" type="text/css" href="{{ csspath }}">
   </head>
   <body>
+    {{ filename }}
     {{ code }}
   </body>
 </html>

--- a/conf/report/code.css
+++ b/conf/report/code.css
@@ -1,0 +1,58 @@
+.highlight .hll { background-color: #ffffcc }
+.highlight .c { color: #228B22 } /* Comment */
+.highlight .err { color: #a61717; background-color: #e3d2d2 } /* Error */
+.highlight .k { color: #8B008B; font-weight: bold } /* Keyword */
+.highlight .cm { color: #228B22 } /* Comment.Multiline */
+.highlight .cp { color: #1e889b } /* Comment.Preproc */
+.highlight .c1 { color: #228B22 } /* Comment.Single */
+.highlight .cs { color: #8B008B; font-weight: bold } /* Comment.Special */
+.highlight .gd { color: #aa0000 } /* Generic.Deleted */
+.highlight .ge { font-style: italic } /* Generic.Emph */
+.highlight .gr { color: #aa0000 } /* Generic.Error */
+.highlight .gh { color: #000080; font-weight: bold } /* Generic.Heading */
+.highlight .gi { color: #00aa00 } /* Generic.Inserted */
+.highlight .go { color: #888888 } /* Generic.Output */
+.highlight .gp { color: #555555 } /* Generic.Prompt */
+.highlight .gs { font-weight: bold } /* Generic.Strong */
+.highlight .gu { color: #800080; font-weight: bold } /* Generic.Subheading */
+.highlight .gt { color: #aa0000 } /* Generic.Traceback */
+.highlight .kc { color: #8B008B; font-weight: bold } /* Keyword.Constant */
+.highlight .kd { color: #8B008B; font-weight: bold } /* Keyword.Declaration */
+.highlight .kn { color: #8B008B; font-weight: bold } /* Keyword.Namespace */
+.highlight .kp { color: #8B008B; font-weight: bold } /* Keyword.Pseudo */
+.highlight .kr { color: #8B008B; font-weight: bold } /* Keyword.Reserved */
+.highlight .kt { color: #a7a7a7; font-weight: bold } /* Keyword.Type */
+.highlight .m { color: #B452CD } /* Literal.Number */
+.highlight .s { color: #CD5555 } /* Literal.String */
+.highlight .na { color: #658b00 } /* Name.Attribute */
+.highlight .nb { color: #658b00 } /* Name.Builtin */
+.highlight .nc { color: #008b45; font-weight: bold } /* Name.Class */
+.highlight .no { color: #00688B } /* Name.Constant */
+.highlight .nd { color: #707a7c } /* Name.Decorator */
+.highlight .ne { color: #008b45; font-weight: bold } /* Name.Exception */
+.highlight .nf { color: #008b45 } /* Name.Function */
+.highlight .nn { color: #008b45; text-decoration: underline } /* Name.Namespace */
+.highlight .nt { color: #8B008B; font-weight: bold } /* Name.Tag */
+.highlight .nv { color: #00688B } /* Name.Variable */
+.highlight .ow { color: #8B008B } /* Operator.Word */
+.highlight .w { color: #bbbbbb } /* Text.Whitespace */
+.highlight .mf { color: #B452CD } /* Literal.Number.Float */
+.highlight .mh { color: #B452CD } /* Literal.Number.Hex */
+.highlight .mi { color: #B452CD } /* Literal.Number.Integer */
+.highlight .mo { color: #B452CD } /* Literal.Number.Oct */
+.highlight .sb { color: #CD5555 } /* Literal.String.Backtick */
+.highlight .sc { color: #CD5555 } /* Literal.String.Char */
+.highlight .sd { color: #CD5555 } /* Literal.String.Doc */
+.highlight .s2 { color: #CD5555 } /* Literal.String.Double */
+.highlight .se { color: #CD5555 } /* Literal.String.Escape */
+.highlight .sh { color: #1c7e71; font-style: italic } /* Literal.String.Heredoc */
+.highlight .si { color: #CD5555 } /* Literal.String.Interpol */
+.highlight .sx { color: #cb6c20 } /* Literal.String.Other */
+.highlight .sr { color: #1c7e71 } /* Literal.String.Regex */
+.highlight .s1 { color: #CD5555 } /* Literal.String.Single */
+.highlight .ss { color: #CD5555 } /* Literal.String.Symbol */
+.highlight .bp { color: #658b00 } /* Name.Builtin.Pseudo */
+.highlight .vc { color: #00688B } /* Name.Variable.Class */
+.highlight .vg { color: #00688B } /* Name.Variable.Global */
+.highlight .vi { color: #00688B } /* Name.Variable.Instance */
+.highlight .il { color: #B452CD } /* Literal.Number.Integer.Long */

--- a/conf/report/code.css
+++ b/conf/report/code.css
@@ -56,3 +56,17 @@
 .highlight .vg { color: #00688B } /* Name.Variable.Global */
 .highlight .vi { color: #00688B } /* Name.Variable.Instance */
 .highlight .il { color: #B452CD } /* Literal.Number.Integer.Long */
+
+.highlight pre {
+  margin: 0;
+}
+
+.linenodiv a {
+  color: #000000;
+  text-decoration: none;
+}
+
+.linenodiv a:hover {
+  text-decoration: underline;
+}
+

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -72,8 +72,7 @@ lex = lexers.get_lexer_by_name("systemverilog")
 
 def formatSrc(ifile, ofile):
     formatter = HtmlFormatter(full=False, linenos=True,
-                              anchorlinenos=True, lineanchors='l',
-                              filename=os.path.relpath(ifile))
+                              anchorlinenos=True, lineanchors='l')
     with open(ifile, 'rb') as f:
         raw_code = f.read()
         os.makedirs(os.path.dirname(ofile), exist_ok=True)
@@ -88,8 +87,11 @@ def formatSrc(ifile, ofile):
         with open(ofile, 'w') as out:
             src_rel = "../" * (ofile.count('/') - 1)
             csspath = os.path.join(src_rel, "code.css")
+            filename = os.path.relpath(ifile)
 
-            out.write(template.render(csspath=csspath, code=code))
+            out.write(template.render(csspath=csspath,
+                                      filename=filename,
+                                      code=code))
 
 
 def logToHTML(path, tags):

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -35,6 +35,10 @@ parser.add_argument("-t", "--template",
                     help="Path to the html report tepmplate",
                     default="conf/report/report-template.html")
 
+parser.add_argument("-T", "--code-template",
+                    help="Path to the html code preview template",
+                    default="conf/report/code-template.html")
+
 parser.add_argument("-o", "--out",
                     help="Path to the html file with the report",
                     default="out/report.html")
@@ -67,14 +71,25 @@ lex = lexers.get_lexer_by_name("systemverilog")
 
 
 def formatSrc(ifile, ofile):
-    formatter = HtmlFormatter(full=True, linenos=True,
+    formatter = HtmlFormatter(full=False, linenos=True,
                               anchorlinenos=True, lineanchors='l',
                               filename=os.path.relpath(ifile))
     with open(ifile, 'rb') as f:
-        code = f.read()
+        raw_code = f.read()
         os.makedirs(os.path.dirname(ofile), exist_ok=True)
+
+        with open(args.code_template, "r") as tl:
+            template = jinja2.Template(tl.read(),
+                                       trim_blocks=True,
+                                       lstrip_blocks=True)
+
+        code = highlight(raw_code, lex, formatter)
+
         with open(ofile, 'w') as out:
-            highlight(code, lex, formatter, outfile=out)
+            src_rel = "../" * (ofile.count('/') - 1)
+            csspath = os.path.join(src_rel, "code.css")
+
+            out.write(template.render(csspath=csspath, code=code))
 
 
 def logToHTML(path, tags):

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -32,7 +32,7 @@ parser.add_argument("-l", "--logs",
                     default="out/logs")
 
 parser.add_argument("-t", "--template",
-                    help="Path to the html report tepmplate",
+                    help="Path to the html report template",
                     default="conf/report/report-template.html")
 
 parser.add_argument("-T", "--code-template",


### PR DESCRIPTION
This is a PR to allow us to apply custom css styles for pygments.

This is useful because:
* Allows us to use one css file for all files (at the moment each code listing includes its own copy of the css)
* Should make it easier to add support for line highlighting (when clicking on an error in a specific line in a log file)


How it looked before this PR (note the misaligned line numbers and code):
![2019-10-02-152732](https://user-images.githubusercontent.com/8438531/66048167-5ee50d00-e529-11e9-8148-b10ffb3f334e.png)

And now:
![2019-10-02-152743](https://user-images.githubusercontent.com/8438531/66048193-699fa200-e529-11e9-80a4-d3f580afdf1a.png)

And note that this is still mostly a door for further improvements (which should be now easy with an external css).
