### PR TITLE
Run dependabot less frequently

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,5 @@
+version: 1
+update_configs:
+  - package_manager: "submodules"
+    directory: "/third_party"
+    update_schedule: "weekly"


### PR DESCRIPTION
It creates too many PRs that we don't merge regularly anyway and creates
a lot of CI builds which block the CI builds for PRs that we actually
care about.