### PR TITLE
report: add a footer with git rev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ tests:
 generate-tests:
 
 report: init info tests
-	./tools/sv-report
+	./tools/sv-report --revision $(shell git rev-parse --short HEAD)
 	cp $(CONF_DIR)/report/*.css $(OUT_DIR)/deploy/
 	cp $(CONF_DIR)/report/*.js $(OUT_DIR)/deploy/
 

--- a/conf/report/report-template.html
+++ b/conf/report/report-template.html
@@ -132,4 +132,10 @@
     <a href="report.csv">Download a summary in csv</a>
   </body>
 
+  <br> <br>
+  <footer>
+    Generated using <a href="https://github.com/SymbiFlow/sv-tests">sv-tests</a>,
+    revision: <a href="https://github.com/SymbiFlow/sv-tests/commit/{{revision}}">{{revision}}</a>.
+  </footer>
+
 </html>

--- a/conf/report/report.css
+++ b/conf/report/report.css
@@ -149,3 +149,7 @@ table.dataTable tfoot th {
 
 button:focus {outline:0;}
 
+footer {
+  text-align: center;
+  font-size: 10px;
+}

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -47,6 +47,10 @@ parser.add_argument("-c", "--csv",
                     help="Path to the csv file with the report",
                     default="out/deploy/report.csv")
 
+parser.add_argument("-r", "--revision",
+                    help="Report revision",
+                    default="unknown")
+
 # parse args
 args = parser.parse_args()
 
@@ -342,7 +346,9 @@ try:
                                  lstrip_blocks=True)
 
     with open(args.out, 'w') as f:
-        f.write(report.render(report=data, database=database))
+        f.write(report.render(report=data,
+                              database=database,
+                              revision=args.revision))
 
     with open(args.csv, 'w', newline='') as csvfile:
         writer = csv.DictWriter(csvfile, fieldnames=csv_header)


### PR DESCRIPTION
This adds a small footer to the report with a link to the github repository and info about the commit from which the report has been generated.
It is useful because it is not always clear whether the report has been generated from the latest master (as the CI is often busy doing other stuff).

Here is a screenshot:
![2019-10-04-124356](https://user-images.githubusercontent.com/8438531/66201898-bb206c00-e6a4-11e9-8a83-cbc717b08955.png)
