### PR TITLE
Add a html template for the log files

### DIFF
--- a/conf/report/log-template.html
+++ b/conf/report/log-template.html
@@ -1,0 +1,11 @@
+<pre>
+description: {{description}}
+should_fail: {{should_fail}}
+tags: {{tags}}
+incdirs: {{incdirs}}
+top_module: {{top_module}}
+files: {{file_urls}}
+
+{{log_urls}}
+
+</pre>

--- a/conf/report/log-template.html
+++ b/conf/report/log-template.html
@@ -1,4 +1,7 @@
 <pre>
+<h3>
+<a href="{{runner_url}}" target="_blank">{{runner}}</a>
+</h3>
 description: {{description}}
 should_fail: {{should_fail}}
 tags: {{tags}}

--- a/tools/BaseRunner.py
+++ b/tools/BaseRunner.py
@@ -24,6 +24,8 @@ class BaseRunner:
         self.name = name
         self.executable = executable
 
+        self.url = "https://github.com/symbiflow/sv-tests"
+
     def run(self, tmp_dir, params):
         """Run the provided test case
         This method is called by the main runner script (tools/runner).

--- a/tools/runner
+++ b/tools/runner
@@ -122,6 +122,8 @@ try:
     output, rc = runner_obj.run(tmp_dir, test_params)
 
     test_params['rc'] = rc
+    test_params['runner'] = runner_obj.name
+    test_params['runner_url'] = runner_obj.url
 
     tool_should_fail = test_params["should_fail"] == "1"
     tool_failed = test_params["rc"] != 0

--- a/tools/runners/Icarus.py
+++ b/tools/runners/Icarus.py
@@ -5,6 +5,8 @@ class Icarus(BaseRunner):
     def __init__(self):
         super().__init__("icarus", "iverilog")
 
+        self.url = "http://iverilog.icarus.com/"
+
     def prepare_run_cb(self, tmp_dir, params):
         self.cmd = [self.executable, '-i', '-g2012', '-o iverilog.out']
 

--- a/tools/runners/Odin.py
+++ b/tools/runners/Odin.py
@@ -5,6 +5,8 @@ class Odin(BaseRunner):
     def __init__(self):
         super().__init__("odin", "odin_II")
 
+        self.url = "https://verilogtorouting.org/"
+
     def prepare_run_cb(self, tmp_dir, params):
 
         self.cmd = [self.executable, '--permissive', '-o odin.blif', '-V']

--- a/tools/runners/Slang.py
+++ b/tools/runners/Slang.py
@@ -5,6 +5,8 @@ class Slang(BaseRunner):
     def __init__(self):
         super().__init__("slang", "driver")
 
+        self.url = "https://github.com/MikePopoloski/slang"
+
     def prepare_run_cb(self, tmp_dir, params):
         self.cmd = [self.executable]
 

--- a/tools/runners/Sv2v_zachjs.py
+++ b/tools/runners/Sv2v_zachjs.py
@@ -5,6 +5,8 @@ class Sv2v_zachjs(BaseRunner):
     def __init__(self):
         super().__init__("zachjs-sv2v", "zachjs-sv2v")
 
+        self.url = "https://github.com/zachjs/sv2v"
+
     def prepare_run_cb(self, tmp_dir, params):
         self.cmd = [self.executable]
 

--- a/tools/runners/Verilator.py
+++ b/tools/runners/Verilator.py
@@ -7,6 +7,8 @@ class Verilator(BaseRunner):
     def __init__(self):
         super().__init__("verilator", "verilator")
 
+        self.url = "https://www.veripool.org/wiki/verilator"
+
     def prepare_run_cb(self, tmp_dir, params):
         scr = os.path.join(tmp_dir, 'scr.sh')
 

--- a/tools/runners/Yosys.py
+++ b/tools/runners/Yosys.py
@@ -7,6 +7,8 @@ class Yosys(BaseRunner):
     def __init__(self):
         super().__init__("yosys", "yosys")
 
+        self.url = "http://www.clifford.at/yosys/"
+
     def prepare_run_cb(self, tmp_dir, params):
         scr = os.path.join(tmp_dir, 'scr.ys')
 

--- a/tools/runners/tree_sitter_verilog.py
+++ b/tools/runners/tree_sitter_verilog.py
@@ -9,6 +9,8 @@ class tree_sitter_verilog(BaseRunner):
     def __init__(self):
         super().__init__("tree-sitter-verilog")
 
+        self.url = "https://github.com/tree-sitter/tree-sitter-verilog"
+
     def log_error(self, fname, row, col, err):
         self.log += '{}:{}:{}: error: {}\n'.format(fname, row, col, err)
 

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -114,8 +114,6 @@ def logToHTML(path_in, path_out, tags):
     src_relative = '../' * depth
     files = tags['files'].split()
     log = tags['log']
-    tag_list = ['name', 'description', 'should_fail',
-                'tags', 'incdirs', 'top_module']
     html_pat_ln = r'{}:(\d+)'
     html_sub_ln = r'<a href="{0}{1}.html#l-\1" target="file-frame">{1}:\1</a>'
 
@@ -123,7 +121,6 @@ def logToHTML(path_in, path_out, tags):
     tags['tool_url'] = "toolname.pl"
 
     tags['file_urls'] = []
-
 
     for f in files:
         f_rel = os.path.relpath(f)
@@ -203,7 +200,7 @@ for r in [os.path.dirname(r) for r in glob(args.logs + "/*/")]:
 
         test_tags = ["name", "tags", "should_fail", "rc",
                      "description", "files", "incdirs",
-                     "top_module"]
+                     "top_module", "runner", "runner_url"]
         with open(t, "r") as f:
             try:
                 for l in f:

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -31,13 +31,17 @@ parser.add_argument("-l", "--logs",
                     help="Directory with all the individual test results",
                     default="out/logs")
 
-parser.add_argument("-t", "--template",
+parser.add_argument("--template",
                     help="Path to the html report template",
                     default="conf/report/report-template.html")
 
-parser.add_argument("-T", "--code-template",
+parser.add_argument("--code-template",
                     help="Path to the html code preview template",
                     default="conf/report/code-template.html")
+
+parser.add_argument("--log-template",
+                    help="Path to the html log template",
+                    default="conf/report/log-template.html")
 
 parser.add_argument("-o", "--out",
                     help="Path to the html file with the report",
@@ -114,24 +118,35 @@ def logToHTML(path_in, path_out, tags):
                 'tags', 'incdirs', 'top_module']
     html_pat_ln = r'{}:(\d+)'
     html_sub_ln = r'<a href="{0}{1}.html#l-\1" target="file-frame">{1}:\1</a>'
-    with open(path_out + '.html', 'w') as html:
-        html.write('<pre>')
-        for tag in tag_list:
-            html.write('{}: {}\n'.format(tag, tags[tag]))
-        html.write('files:')
-        for f in files:
-            f_rel = os.path.relpath(f)
-            f_html = ('<a href="{0}{1}.html" target="file-frame">{1}</a>'
-                      .format(src_relative, f_rel))
-            log = re.sub(html_pat_ln.format(f),
-                         html_sub_ln.format(src_relative, f_rel), log)
-            log = re.sub(f, f_html, log)
-            formatSrc(f, os.path.join(os.path.dirname(args.out),
-                      f_rel + '.html'))
-            html.write(' ' + f_html)
-        html.write('\n')
-        html.write(log)
-        html.write('</pre>')
+
+    tags['tool'] = "toolname"
+    tags['tool_url'] = "toolname.pl"
+
+    tags['file_urls'] = []
+
+
+    for f in files:
+        f_rel = os.path.relpath(f)
+        f_html = ('<a href="{0}{1}.html" target="file-frame">{1}</a>'
+                  .format(src_relative, f_rel))
+        log = re.sub(html_pat_ln.format(f),
+                     html_sub_ln.format(src_relative, f_rel), log)
+        log = re.sub(f, f_html, log)
+        formatSrc(f, os.path.join(os.path.dirname(args.out),
+                  f_rel + '.html'))
+
+        tags['file_urls'].append(f_html)
+
+    tags['file_urls'] = " ".join(tags['file_urls'])
+    tags['log_urls'] = log
+
+    with open(args.log_template, "r") as templ:
+        logf = jinja2.Template(templ.read(),
+                               trim_blocks=True,
+                               lstrip_blocks=True)
+
+    with open(path_out + ".html", 'w') as html:
+        html.write(logf.render(**tags))
 
     return os.path.relpath(files[0]) + '.html'
 


### PR DESCRIPTION
Generate the logs using a template too.

Add a link to each tool in the log (fixes #76)

With this change, the log looks like this:
![2019-10-07-110057](https://user-images.githubusercontent.com/8438531/66298366-da600900-e8f1-11e9-9333-48a1b1c8d54c.png)

The name of the tool in the log is a link to the projects website.

Another change here is removing the short arguments for templates. There are multiple templates already, we may want to just move them to a separate directory and have an argument for all of them together, but for now, just change them to long arguments only,