### PR TITLE
Don't make generator running silent.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ endef
 
 define generator_gen
 generate-$(1):
-	@$(GENERATORS_DIR)/$(1) $(1)
+	$(GENERATORS_DIR)/$(1) $(1)
 
 generate-tests: generate-$(1)
 endef


### PR DESCRIPTION
Unless @echo, Makefile rules should never be silent so that
it is observable what the build-system is doing.

(Fixes #80)

Signed-off-by: Henner Zeller <h.zeller@acm.org>