### PR TITLE
Make message about a non-found runner a debug-log.

### DIFF
--- a/tools/check-runners
+++ b/tools/check-runners
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import os
-import sys
 import argparse
 import logging
 

--- a/tools/check-runners
+++ b/tools/check-runners
@@ -3,6 +3,8 @@
 import os
 import sys
 import argparse
+import logging
+
 from importlib import import_module
 
 parser = argparse.ArgumentParser()
@@ -11,6 +13,7 @@ parser.add_argument("runners", metavar='runner',
                     type=str, nargs='+')
 
 args = parser.parse_args()
+logger = logging.getLogger()
 
 runner_obj = None
 
@@ -32,4 +35,4 @@ for runner in args.runners:
     if runner_obj.can_run():
         print(runner)
     else:
-        print('Runner {} not found'.format(runner), file=sys.stderr)
+        logger.debug('Runner {} not found'.format(runner))


### PR DESCRIPTION
Before, every invocation of 'make', which determines the
runners to generate rules, will output a confusing message
about the non-found runners (even if invoking targets that
don't even have to deal with it, e.g. generate-tests).

Signed-off-by: Henner Zeller <h.zeller@acm.org>