### PR TITLE
Don't run unrelated 'info'-target when generating the report.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ tests:
 
 generate-tests:
 
-report: init info tests
+report: init tests
 	./tools/sv-report --revision $(shell git rev-parse --short HEAD)
 	cp $(CONF_DIR)/report/*.css $(OUT_DIR)/deploy/
 	cp $(CONF_DIR)/report/*.js $(OUT_DIR)/deploy/


### PR DESCRIPTION
This looks like a left-over from the early days, when the
tool-runners were still silent; now it just adds noise.

Signed-off-by: Henner Zeller <h.zeller@acm.org>