### PR TITLE
Numeric literals should not start with underscore (_)

### DIFF
--- a/tests/generic/number/number_test_63.sv
+++ b/tests/generic/number/number_test_63.sv
@@ -1,7 +1,7 @@
 /*
 :name: number_test_63
-:description: Test
-:should_fail: 0
+:description: Hex literal with invalid leading underscore prefix should fail.
+:should_fail: 1
 :tags: 5.6.4 5.7.1 5.7.2
 */
 parameter int foo = 32'H_7f_FF_;


### PR DESCRIPTION
(5.7.1 fineprint).

Fixes #240

Signed-off-by: Henner Zeller <h.zeller@acm.org>