### PR TITLE
Avoid multiple generation of src-file HTML.

### DIFF
--- a/tools/sv-report
+++ b/tools/sv-report
@@ -73,8 +73,13 @@ tag_usage = {}
 
 lex = lexers.get_lexer_by_name("systemverilog")
 
+def exists_and_is_newer_than(b, a):
+    return os.path.exists(b) and os.path.getctime(b) > os.path.getctime(a)
 
 def formatSrc(ifile, ofile):
+    if exists_and_is_newer_than(ofile, ifile):
+        return
+
     formatter = HtmlFormatter(full=False, linenos=True,
                               anchorlinenos=True, lineanchors='l')
     with open(ifile, 'rb') as f:

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -73,8 +73,10 @@ tag_usage = {}
 
 lex = lexers.get_lexer_by_name("systemverilog")
 
+
 def exists_and_is_newer_than(b, a):
     return os.path.exists(b) and os.path.getctime(b) > os.path.getctime(a)
+
 
 def formatSrc(ifile, ofile):
     if exists_and_is_newer_than(ofile, ifile):


### PR DESCRIPTION
The same source file can be mentioned multiple times, so make
sure to only generate it the first time.

(This speeds up sv-report 3x)

Signed-off-by: Henner Zeller <h.zeller@acm.org>