### PR TITLE
tests: fix issues with newline escaping in macro definitions

### DIFF
--- a/tests/generic/preproc/preproc_test_10.sv
+++ b/tests/generic/preproc/preproc_test_10.sv
@@ -4,6 +4,6 @@
 :should_fail: 0
 :tags: 5.6.4
 */
-`define LONG_MACRO(\
-    a,\
+`define LONG_MACRO(
+    a,
     b, c) text goes here

--- a/tests/generic/preproc/preproc_test_11.sv
+++ b/tests/generic/preproc/preproc_test_11.sv
@@ -4,10 +4,10 @@
 :should_fail: 0
 :tags: 5.6.4
 */
-`define LONG_MACRO(\
-    a,\
-    b\
-, c\
+`define LONG_MACRO(
+    a,
+    b
+, c
 ) \
 more text c, b, a \
 blah blah macro ends here

--- a/tests/generic/preproc/preproc_test_12.sv
+++ b/tests/generic/preproc/preproc_test_12.sv
@@ -4,6 +4,6 @@
 :should_fail: 0
 :tags: 5.6.4
 */
-`define LONG_MACRO(\
+`define LONG_MACRO(
     a, b=2, c=42) \
 a + b /c +345

--- a/tests/generic/preproc/preproc_test_13.sv
+++ b/tests/generic/preproc/preproc_test_13.sv
@@ -4,6 +4,6 @@
 :should_fail: 0
 :tags: 5.6.4
 */
-`define LONG_MACRO(\
+`define LONG_MACRO(
     a, b="(3,2)", c=(3,2)) \
 a + b /c +345

--- a/tests/generic/preproc/preproc_test_9.sv
+++ b/tests/generic/preproc/preproc_test_9.sv
@@ -4,5 +4,5 @@
 :should_fail: 0
 :tags: 5.6.4
 */
-`define LONG_MACRO(\
+`define LONG_MACRO(
     a, b, c)


### PR DESCRIPTION
As pointed out in #239, LRM doesn't allow for line continuations in argument lists but states that arguments can be separated using whitespace and newline is counted as whitespace character by the LRM in `5.3`.
That means that multiline argument list without newline escaping should be all right.

Fixes #239 