### PR TITLE
Limit resources the runners can take to run.

### DIFF
--- a/tools/BaseRunner.py
+++ b/tools/BaseRunner.py
@@ -1,5 +1,10 @@
-import subprocess
+import resource
 import shutil
+import subprocess
+
+def set_process_limits():
+    """Make sure processes behave. Limit memory to 4GiB"""
+    resource.setrlimit(resource.RLIMIT_DATA, (4<<30, 4<<30))
 
 
 class BaseRunner:
@@ -26,6 +31,7 @@ class BaseRunner:
 
         self.url = "https://github.com/symbiflow/sv-tests"
 
+
     def run(self, tmp_dir, params):
         """Run the provided test case
         This method is called by the main runner script (tools/runner).
@@ -40,12 +46,14 @@ class BaseRunner:
         self.prepare_run_cb(tmp_dir, params)
 
         proc = subprocess.Popen(self.cmd, cwd=tmp_dir,
+                                preexec_fn=set_process_limits,
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.STDOUT)
 
         log, _ = proc.communicate()
 
         return (log.decode('utf-8'), proc.returncode)
+
 
     def can_run(self):
         """Check if runner can be used

--- a/tools/BaseRunner.py
+++ b/tools/BaseRunner.py
@@ -2,9 +2,10 @@ import resource
 import shutil
 import subprocess
 
+
 def set_process_limits():
     """Make sure processes behave. Limit memory to 4GiB"""
-    resource.setrlimit(resource.RLIMIT_DATA, (4<<30, 4<<30))
+    resource.setrlimit(resource.RLIMIT_DATA, (4 << 30, 4 << 30))
 
 
 class BaseRunner:
@@ -31,7 +32,6 @@ class BaseRunner:
 
         self.url = "https://github.com/symbiflow/sv-tests"
 
-
     def run(self, tmp_dir, params):
         """Run the provided test case
         This method is called by the main runner script (tools/runner).
@@ -53,7 +53,6 @@ class BaseRunner:
         log, _ = proc.communicate()
 
         return (log.decode('utf-8'), proc.returncode)
-
 
     def can_run(self):
         """Check if runner can be used


### PR DESCRIPTION
There are versions of `slang` that keep allocating memory until
the test-machine gets in trouble. Limit memory for sub-processes.

Signed-off-by: Henner Zeller <h.zeller@acm.org>