### PR TITLE
makefile: ci: use make format for pep8 checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ jobs:
       install:
         - pip install -r conf/requirements.txt
       script:
-        - "flake8 tools/*.py tools/runners/*.py $(file generators/* tools/* | sed -ne 's/:.*python.*//pI')"
+        - "make format"
 
     - name: "Generate report.hml"
       install:

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,13 @@ endif
 	@echo -e "Found the following runners:$(subst $(space),"\\n \* ", $(RUNNERS))\n"
 	@echo -e "Found the following tests:$(subst $(space),"\\n \* ", $(TESTS))\n"
 
+PY_FILES := $(shell file generators/* tools/* | sed -ne 's/:.*python.*//pI')
+PY_FILES += $(wildcard tools/*.py)
+PY_FILES += $(wildcard tools/runners/*.py)
+
+format:
+	flake8 $(PY_FILES)
+
 tests:
 
 generate-tests:


### PR DESCRIPTION
This adds `make format` target for pep8 checks and replaces check in CI with it
Fixes #261