### PR TITLE
Add more tests from hdlConvertor

### DIFF
--- a/conf/generators/meta-path/hdlconvertor.json
+++ b/conf/generators/meta-path/hdlconvertor.json
@@ -3,7 +3,8 @@
 	"project": "hdlconv",
 	"should_fail": "0",
 	"paths": [
-		["tests", "hdlconvertor", "tests", "sv_test", "*"]
+		["tests", "hdlconvertor", "tests", "sv_test", "*"],
+		["tests", "hdlconvertor", "tests", "verilog"]
 	],
-	"matches": ["*.sv"]
+	"matches": ["*.sv", "*.v"]
 }


### PR DESCRIPTION
#129 added most of them, but tests located outside of `std2012` and `std2017` directories were omitted.
This aims to add tests from `sv_pp` and `verilog` which are preprocessor tests older verilog tests.
Closes #56