### PR TITLE
Sort test-case names within one tag

### DIFF
--- a/conf/report/report-template.html
+++ b/conf/report/report-template.html
@@ -60,10 +60,11 @@
                 onclick='toggleLog("{{tool}}", "{{tag}}", null, null)'>
           close
         </button>
-        {% for test, output in tooldata["tags"][tag]["logs"].items() %}
+        {% for test, output in tooldata["tags"][tag]["logs_sorted"] %}
         <button class="logtab-btn
                        logtab-tab-btn
                        {{output["status"]}}
+                       sorted
                        "
                 onclick='selectTab("{{output["fname"]}}",
                                    "logtab-btn-{{tool}}-{{tag}}-{{test}}",
@@ -101,8 +102,8 @@
             {% if "test-na" not in tooldata["tags"][tag]["status"] %}
             id='{{tool}}-{{tag}}-cell'
             onclick='toggleLog("{{tool}}", "{{tag}}",
-                               "{{tooldata["tags"][tag]["logs"]|first}}",
-                               "{{tooldata["tags"][tag]["logs"][tooldata["tags"][tag]["logs"]|first]["first_file"]}}")'
+                               "{{tooldata["tags"][tag]["head_test"]}}",
+                               "{{tooldata["tags"][tag]["logs"][tooldata["tags"][tag]["head_test"]]["first_file"]}}")'
             {% endif %}
             >
             {% if "test-na" not in tooldata["tags"][tag]["status"] %}

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -155,6 +155,25 @@ def getRelativePaths(paths):
     return ' '.join(paths)
 
 
+# class used for sorting "test tabs" in the report
+class TestTupleComp(object):
+    def __init__(self, item):
+        self.item = item
+
+    def prepend_nums(self, s):
+        # prepend all number occurences with the length of the number
+        for m in re.findall(r'\d+', s):
+            s = s.replace(m, str(len(m)) + m)
+
+        return s
+
+    def __lt__(self, other):
+        s = self.prepend_nums(self.item[1]["name"])
+        o = self.prepend_nums(other.item[1]["name"])
+
+        return s < o
+
+
 # generate input database first
 database = {}
 try:
@@ -347,6 +366,13 @@ try:
                     inner["name"] = test_handle["name"]
                     inner["fname"] = test_handle["fname"]
                     inner["first_file"] = test_handle["first_file"]
+
+            # sort logs
+            tag_handle["logs_sorted"] = sorted(tag_handle["logs"].items(),
+                                               key=TestTupleComp)
+            if len(tag_handle["logs_sorted"]) > 0:
+                tag_handle["head_test"] = tag_handle["logs_sorted"][0][0]
+
         data[r]["total"] = {}
 
         # find the number of tests that passed


### PR DESCRIPTION
Implements algorithm suggested in #267.

A new copy with sorted test data has to be created as python dicts are not ordered.

Fixes #267

Signed-off-by: Tomasz Gorochowik <tgorochowik@antmicro.com>