### PR TITLE
Modify python format checks to use yapf

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -1,0 +1,6 @@
+[style]
+based_on_style = pep8
+split_before_expression_after_opening_paren = True
+split_before_first_argument = True
+split_complex_comprehension = True
+split_penalty_comprehension = 2100

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ jobs:
         - pip install -r conf/requirements.txt
       script:
         - "make format"
+        - "test $(git status --porcelain | wc -l) -eq 0 || { git diff; false; }"
 
     - name: "Generate report.hml"
       install:

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ PY_FILES += $(wildcard tools/*.py)
 PY_FILES += $(wildcard tools/runners/*.py)
 
 format:
-	flake8 $(PY_FILES)
+	python3 -m yapf -p -i $(PY_FILES)
 
 tests:
 

--- a/conf/requirements.txt
+++ b/conf/requirements.txt
@@ -1,5 +1,5 @@
 conan
-flake8
 jinja2
 tree_sitter
 pygments
+yapf

--- a/generators/ibex
+++ b/generators/ibex
@@ -36,8 +36,8 @@ incdirs = ''
 
 groups = ['ibex', 'ibex_regfile_fpga']
 
-sources += os.path.join(ibex_path,
-                        'examples/sim/rtl/prim_clock_gating.sv') + ' '
+sources += os.path.join(
+    ibex_path, 'examples/sim/rtl/prim_clock_gating.sv') + ' '
 
 with open(ibex_yaml, "r") as f:
     y = yaml.safe_load(f)

--- a/generators/path_generator
+++ b/generators/path_generator
@@ -28,8 +28,8 @@ should_fail = ''
 paths = [[]]
 matches = []
 
-for cfg in glob.glob(os.path.join(conf_dir, 'generators',
-                                  'meta-path', '*.json')):
+for cfg in glob.glob(os.path.join(conf_dir, 'generators', 'meta-path',
+                                  '*.json')):
     with open(cfg, 'r') as jf:
         data = json.load(jf)
         name = data['name']
@@ -52,5 +52,4 @@ for cfg in glob.glob(os.path.join(conf_dir, 'generators',
                 test_file = os.path.join(test_dir, fname + '.sv')
 
                 with open(test_file, "w") as sv:
-                    sv.write(templ.format(project, should_fail,
-                                          f, fname))
+                    sv.write(templ.format(project, should_fail, f, fname))

--- a/generators/swerv
+++ b/generators/swerv
@@ -34,13 +34,12 @@ swerv_flist = os.path.join(swerv_path, "testbench", "flist.verilator")
 sources = ''
 
 sources += os.path.join(
-           swerv_path, "configs", "snapshots",
-           "default", "common_defines.vh") + ' '
+    swerv_path, "configs", "snapshots", "default", "common_defines.vh") + ' '
 
 sources += os.path.join(swerv_path, "design", "include", "build.h") + ' '
 sources += os.path.join(swerv_path, "design", "include", "global.h") + ' '
 sources += os.path.join(
-           swerv_path, "design", "include", "swerv_types.sv") + ' '
+    swerv_path, "design", "include", "swerv_types.sv") + ' '
 
 with open(swerv_flist, "r") as f:
     for l in f:

--- a/generators/template_generator
+++ b/generators/template_generator
@@ -17,8 +17,8 @@ fname = ''
 templ = ''
 vals = []
 
-for cfg in glob.glob(os.path.join(conf_dir, 'generators',
-                                  'templates', '*.json')):
+for cfg in glob.glob(os.path.join(conf_dir, 'generators', 'templates',
+                                  '*.json')):
     with open(cfg, 'r') as jf:
         data = json.load(jf)
         name = data['name']

--- a/tools/BaseRunner.py
+++ b/tools/BaseRunner.py
@@ -19,7 +19,6 @@ class BaseRunner:
     Runners must be located in tools/runners subdirectory
     to be detected and launched by the Makefile.
     """
-
     def __init__(self, name, executable=None):
         """Base runner class constructor
         Arguments:
@@ -45,10 +44,12 @@ class BaseRunner:
         """
         self.prepare_run_cb(tmp_dir, params)
 
-        proc = subprocess.Popen(self.cmd, cwd=tmp_dir,
-                                preexec_fn=set_process_limits,
-                                stdout=subprocess.PIPE,
-                                stderr=subprocess.STDOUT)
+        proc = subprocess.Popen(
+            self.cmd,
+            cwd=tmp_dir,
+            preexec_fn=set_process_limits,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT)
 
         log, _ = proc.communicate()
 

--- a/tools/check-runners
+++ b/tools/check-runners
@@ -8,8 +8,7 @@ from importlib import import_module
 
 parser = argparse.ArgumentParser()
 
-parser.add_argument("runners", metavar='runner',
-                    type=str, nargs='+')
+parser.add_argument("runners", metavar='runner', type=str, nargs='+')
 
 args = parser.parse_args()
 logger = logging.getLogger()
@@ -26,8 +25,10 @@ for runner in args.runners:
     except Exception:
         continue
 
-    new_path = [os.path.abspath(os.environ['OUT_DIR'] + "/runners/bin/"),
-                os.environ['PATH']]
+    new_path = [
+        os.path.abspath(os.environ['OUT_DIR'] + "/runners/bin/"),
+        os.environ['PATH']
+    ]
 
     os.environ['PATH'] = ":".join(new_path)
 

--- a/tools/runner
+++ b/tools/runner
@@ -11,17 +11,19 @@ from importlib import import_module
 
 parser = argparse.ArgumentParser()
 
-parser.add_argument("-r", "--runner",
-                    required=True)
+parser.add_argument("-r", "--runner", required=True)
 
-parser.add_argument("-t", "--test",
-                    required=True)
+parser.add_argument("-t", "--test", required=True)
 
-parser.add_argument("-o", "--out",
-                    required=True)
+parser.add_argument("-o", "--out", required=True)
 
-parser.add_argument("-q", "--quiet", dest='verbosity', action='store_const',
-                    const=logging.ERROR, default=logging.DEBUG)
+parser.add_argument(
+    "-q",
+    "--quiet",
+    dest='verbosity',
+    action='store_const',
+    const=logging.ERROR,
+    default=logging.DEBUG)
 
 args = parser.parse_args()
 
@@ -61,9 +63,10 @@ runner = os.path.abspath(os.path.join(dirs['runners'], args.runner))
 test = os.path.abspath(os.path.join(dirs['tests'], args.test))
 out = os.path.abspath(args.out)
 
-req_test_params = ["name", "tags", "description",
-                   "should_fail", "files", "incdirs",
-                   "top_module"]
+req_test_params = [
+    "name", "tags", "description", "should_fail", "files", "incdirs",
+    "top_module"
+]
 
 test_params = {}
 
@@ -80,8 +83,9 @@ try:
             param_value = param.group(2)
 
             if param_name not in req_test_params:
-                logger.warning("Unsupported test param found: {} - ignoring"
-                               .format(param_name))
+                logger.warning(
+                    "Unsupported test param found: {} - ignoring".format(
+                        param_name))
                 continue
 
             test_params[param_name] = param_value
@@ -98,8 +102,9 @@ try:
 
             if len(set(req_test_params) - set(test_params.keys())) != 0:
                 missing = list(set(req_test_params) - set(test_params.keys()))
-                logger.error("Required parameters missing ({}) in {}"
-                             .format(", ".join(missing), args.test))
+                logger.error(
+                    "Required parameters missing ({}) in {}".format(
+                        ", ".join(missing), args.test))
                 sys.exit(1)
 except Exception as e:
     logger.error("Unable to parse test file: {}".format(str(e)))
@@ -111,13 +116,12 @@ test_params['incdirs'] = test_params['incdirs'].split()
 try:
     tmp_dir = tempfile.mkdtemp()
 except (PermissionError, FileExistsError) as e:
-    logger.error("Unable to create a temporary directory for test: {}"
-                 .format(str(e)))
+    logger.error(
+        "Unable to create a temporary directory for test: {}".format(str(e)))
     sys.exit(1)
 
 try:
-    logger.info("Running {}/{}"
-                .format(args.runner, args.test))
+    logger.info("Running {}/{}".format(args.runner, args.test))
 
     output, rc = runner_obj.run(tmp_dir, test_params)
 
@@ -147,8 +151,9 @@ try:
         log.write("\n")
         log.write(output)
 except Exception as e:
-    logger.error("Unable to test {} using {}: {}"
-                 .format(args.runner, args.test, str(e)))
+    logger.error(
+        "Unable to test {} using {}: {}".format(
+            args.runner, args.test, str(e)))
     sys.exit(1)
 finally:
     shutil.rmtree(tmp_dir)

--- a/tools/runners/tree_sitter_verilog.py
+++ b/tools/runners/tree_sitter_verilog.py
@@ -35,8 +35,8 @@ class tree_sitter_verilog(BaseRunner):
         sv_lib = ''
         try:
             out = os.environ['OUT_DIR']
-            sv_lib = os.path.abspath(os.path.join(out,
-                                     'runners', 'lib', 'verilog.so'))
+            sv_lib = os.path.abspath(
+                os.path.join(out, 'runners', 'lib', 'verilog.so'))
         except KeyError as e:
             print(str(e))
             sys.exit(1)
@@ -67,9 +67,11 @@ class tree_sitter_verilog(BaseRunner):
 
     def can_run(self):
         try:
-            return os.path.isfile(os.path.abspath(os.path.join(
-                                  os.environ['OUT_DIR'], 'runners',
-                                  'lib', 'verilog.so')))
+            return os.path.isfile(
+                os.path.abspath(
+                    os.path.join(
+                        os.environ['OUT_DIR'], 'runners', 'lib',
+                        'verilog.so')))
         except KeyError as e:
             print(str(e))
             return False

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -15,45 +15,50 @@ parser = argparse.ArgumentParser()
 
 logger_args = parser.add_mutually_exclusive_group()
 
-logger_args.add_argument("-q", "--quiet",
-                         action="store_true",
-                         help="Disable all logs")
+logger_args.add_argument(
+    "-q", "--quiet", action="store_true", help="Disable all logs")
 
-logger_args.add_argument("-v", "--verbose",
-                         action="store_true",
-                         help="Verbose logging")
+logger_args.add_argument(
+    "-v", "--verbose", action="store_true", help="Verbose logging")
 
-parser.add_argument("-i", "--input",
-                    help="Input database/LRM",
-                    default="conf/lrm.conf")
+parser.add_argument(
+    "-i", "--input", help="Input database/LRM", default="conf/lrm.conf")
 
-parser.add_argument("-l", "--logs",
-                    help="Directory with all the individual test results",
-                    default="out/logs")
+parser.add_argument(
+    "-l",
+    "--logs",
+    help="Directory with all the individual test results",
+    default="out/logs")
 
-parser.add_argument("--template",
-                    help="Path to the html report template",
-                    default="conf/report/report-template.html")
+parser.add_argument(
+    "--template",
+    help="Path to the html report template",
+    default="conf/report/report-template.html")
 
-parser.add_argument("--code-template",
-                    help="Path to the html code preview template",
-                    default="conf/report/code-template.html")
+parser.add_argument(
+    "--code-template",
+    help="Path to the html code preview template",
+    default="conf/report/code-template.html")
 
-parser.add_argument("--log-template",
-                    help="Path to the html log template",
-                    default="conf/report/log-template.html")
+parser.add_argument(
+    "--log-template",
+    help="Path to the html log template",
+    default="conf/report/log-template.html")
 
-parser.add_argument("-o", "--out",
-                    help="Path to the html file with the report",
-                    default="out/report/index.html")
+parser.add_argument(
+    "-o",
+    "--out",
+    help="Path to the html file with the report",
+    default="out/report/index.html")
 
-parser.add_argument("-c", "--csv",
-                    help="Path to the csv file with the report",
-                    default="out/report/report.csv")
+parser.add_argument(
+    "-c",
+    "--csv",
+    help="Path to the csv file with the report",
+    default="out/report/report.csv")
 
-parser.add_argument("-r", "--revision",
-                    help="Report revision",
-                    default="unknown")
+parser.add_argument(
+    "-r", "--revision", help="Report revision", default="unknown")
 
 # parse args
 args = parser.parse_args()
@@ -86,16 +91,15 @@ def formatSrc(ifile, ofile):
     if exists_and_is_newer_than(ofile, ifile):
         return
 
-    formatter = HtmlFormatter(full=False, linenos=True,
-                              anchorlinenos=True, lineanchors='l')
+    formatter = HtmlFormatter(
+        full=False, linenos=True, anchorlinenos=True, lineanchors='l')
     with open(ifile, 'rb') as f:
         raw_code = f.read()
         os.makedirs(os.path.dirname(ofile), exist_ok=True)
 
         with open(args.code_template, "r") as tl:
-            template = jinja2.Template(tl.read(),
-                                       trim_blocks=True,
-                                       lstrip_blocks=True)
+            template = jinja2.Template(
+                tl.read(), trim_blocks=True, lstrip_blocks=True)
 
         code = highlight(raw_code, lex, formatter)
 
@@ -104,9 +108,8 @@ def formatSrc(ifile, ofile):
             src_rel = "../" * filename.count('/')
             csspath = os.path.join(src_rel, "code.css")
 
-            out.write(template.render(csspath=csspath,
-                                      filename=filename,
-                                      code=code))
+            out.write(
+                template.render(csspath=csspath, filename=filename, code=code))
 
 
 def logToHTML(path_in, path_out, tags):
@@ -124,13 +127,14 @@ def logToHTML(path_in, path_out, tags):
 
     for f in files:
         f_rel = os.path.relpath(f)
-        f_html = ('<a href="{0}{1}.html" target="file-frame">{1}</a>'
-                  .format(src_relative, f_rel))
-        log = re.sub(html_pat_ln.format(f),
-                     html_sub_ln.format(src_relative, f_rel), log)
+        f_html = (
+            '<a href="{0}{1}.html" target="file-frame">{1}</a>'.format(
+                src_relative, f_rel))
+        log = re.sub(
+            html_pat_ln.format(f), html_sub_ln.format(src_relative, f_rel),
+            log)
         log = re.sub(f, f_html, log)
-        formatSrc(f, os.path.join(os.path.dirname(args.out),
-                  f_rel + '.html'))
+        formatSrc(f, os.path.join(os.path.dirname(args.out), f_rel + '.html'))
 
         tags['file_urls'].append(f_html)
 
@@ -138,9 +142,8 @@ def logToHTML(path_in, path_out, tags):
     tags['log_urls'] = log
 
     with open(args.log_template, "r") as templ:
-        logf = jinja2.Template(templ.read(),
-                               trim_blocks=True,
-                               lstrip_blocks=True)
+        logf = jinja2.Template(
+            templ.read(), trim_blocks=True, lstrip_blocks=True)
 
     with open(path_out + ".html", 'w') as html:
         html.write(logf.render(**tags))
@@ -198,17 +201,19 @@ for r in [os.path.dirname(r) for r in glob(args.logs + "/*/")]:
 
         tests[t_id] = {}
 
-        test_tags = ["name", "tags", "should_fail", "rc",
-                     "description", "files", "incdirs",
-                     "top_module", "runner", "runner_url"]
+        test_tags = [
+            "name", "tags", "should_fail", "rc", "description", "files",
+            "incdirs", "top_module", "runner", "runner_url"
+        ]
         with open(t, "r") as f:
             try:
                 for l in f:
                     tag = re.search(r"^([a-zA-Z_-]+):(.+)", l)
 
                     if tag is None:
-                        raise KeyError("Could not find tags: {}"
-                                       .format(", ".join(test_tags)))
+                        raise KeyError(
+                            "Could not find tags: {}".format(
+                                ", ".join(test_tags)))
 
                     param = tag.group(1).lower()
                     value = tag.group(2).strip()
@@ -222,20 +227,20 @@ for r in [os.path.dirname(r) for r in glob(args.logs + "/*/")]:
                             break
                     else:
                         logger.warning(
-                                "Skipping unknown parameter: {} in {}"
-                                .format(param, t))
+                            "Skipping unknown parameter: {} in {}".format(
+                                param, t))
 
             except Exception as e:
-                logger.warning("Skipping {} on {}: {}"
-                               .format(t, r_name, str(e)))
+                logger.warning(
+                    "Skipping {} on {}: {}".format(t, r_name, str(e)))
                 del tests[t_id]
                 continue
 
             tests[t_id]["log"] = f.read()
             tests[t_id]["fname"] = os.path.join('logs', t_id + '.html')
 
-            t_html = t.replace(args.logs,
-                               os.path.join(os.path.dirname(args.out), "logs"))
+            t_html = t.replace(
+                args.logs, os.path.join(os.path.dirname(args.out), "logs"))
             os.makedirs(os.path.dirname(t_html), exist_ok=True)
 
             tests[t_id]["first_file"] = logToHTML(t, t_html, tests[t_id])
@@ -267,11 +272,13 @@ for r in [os.path.dirname(r) for r in glob(args.logs + "/*/")]:
             test["status"] = status
 
             if passed:
-                logger.debug("{} passed {} in {}"
-                             .format(r_name, test["tags"], test["name"]))
+                logger.debug(
+                    "{} passed {} in {}".format(
+                        r_name, test["tags"], test["name"]))
             else:
-                logger.debug("{} failed {} in {}"
-                             .format(r_name, test["tags"], test["name"]))
+                logger.debug(
+                    "{} failed {} in {}".format(
+                        r_name, test["tags"], test["name"]))
 
             for tag in test["tags"].split(" "):
                 try:
@@ -312,9 +319,9 @@ for r in data:
 
         try:
             if csv_output[name]["files"] != files:
-                logger.error("Duplicate test: {}, first use: {}, second: {}"
-                             .format(name, csv_output[name]["files"],
-                                     files))
+                logger.error(
+                    "Duplicate test: {}, first use: {}, second: {}".format(
+                        name, csv_output[name]["files"], files))
                 if name not in duplicates:
                     duplicates.append(name)
             else:
@@ -352,22 +359,21 @@ try:
         # find the number of tests that passed
         rts = data[r]["tests"]
         data[r]["total"]["tests"] = sum(
-                1 for t in rts if rts[t]["status"] in "test-passed")
+            1 for t in rts if rts[t]["status"] in "test-passed")
 
         # find the number of tags for which all the tests passed
         rtt = data[r]["tags"]
         data[r]["total"]["tags"] = sum(
-                1 for t in rtt if rtt[t]["status"] in "test-passed")
+            1 for t in rtt if rtt[t]["status"] in "test-passed")
 
     with open(args.template, "r") as f:
-        report = jinja2.Template(f.read(),
-                                 trim_blocks=True,
-                                 lstrip_blocks=True)
+        report = jinja2.Template(
+            f.read(), trim_blocks=True, lstrip_blocks=True)
 
     with open(args.out, 'w') as f:
-        f.write(report.render(report=data,
-                              database=database,
-                              revision=args.revision))
+        f.write(
+            report.render(
+                report=data, database=database, revision=args.revision))
 
     with open(args.csv, 'w', newline='') as csvfile:
         writer = csv.DictWriter(csvfile, fieldnames=csv_header)


### PR DESCRIPTION
This PR modifies `make format` command to use `yapf` to automatically adjust python code formatting
and adjusts CI to check if the code is formatted properly.
Closes #261