### PR TITLE
Fix decimal number tests with invalid chars

### DIFF
--- a/tests/chapter-5/5.7.1--integers-signed.sv
+++ b/tests/chapter-5/5.7.1--integers-signed.sv
@@ -17,7 +17,7 @@ module top();
                  // be interpreted as a two's-complement number,
                  // or '-1'. This is equivalent to -4'h 1
     c = -4'sd15; // this is equivalent to -(-4'd 1), or '0001'
-    d = 16'sd?;  // the same as 16'sbz
+    d = 16'sb?;  // the same as 16'sbz
   end
 
 endmodule

--- a/tests/generic/number/number_test_31.sv
+++ b/tests/generic/number/number_test_31.sv
@@ -1,7 +1,7 @@
 /*
 :name: number_test_31
 :description: Test
-:should_fail: 0
+:should_fail: 1
 :tags: 5.6.4 5.7.1 5.7.2
 */
 parameter int foo = 32'dx;

--- a/tests/generic/number/number_test_32.sv
+++ b/tests/generic/number/number_test_32.sv
@@ -1,7 +1,7 @@
 /*
 :name: number_test_32
 :description: Test
-:should_fail: 0
+:should_fail: 1
 :tags: 5.6.4 5.7.1 5.7.2
 */
 parameter int foo = 32'dx_;

--- a/tests/generic/number/number_test_33.sv
+++ b/tests/generic/number/number_test_33.sv
@@ -1,7 +1,7 @@
 /*
 :name: number_test_33
 :description: Test
-:should_fail: 0
+:should_fail: 1
 :tags: 5.6.4 5.7.1 5.7.2
 */
 parameter int foo = 32'dx__;

--- a/tests/generic/number/number_test_34.sv
+++ b/tests/generic/number/number_test_34.sv
@@ -1,7 +1,7 @@
 /*
 :name: number_test_34
 :description: Test
-:should_fail: 0
+:should_fail: 1
 :tags: 5.6.4 5.7.1 5.7.2
 */
 parameter int foo = 32'dX;

--- a/tests/generic/number/number_test_35.sv
+++ b/tests/generic/number/number_test_35.sv
@@ -1,7 +1,7 @@
 /*
 :name: number_test_35
 :description: Test
-:should_fail: 0
+:should_fail: 1
 :tags: 5.6.4 5.7.1 5.7.2
 */
 parameter int foo = 32'dz;

--- a/tests/generic/number/number_test_36.sv
+++ b/tests/generic/number/number_test_36.sv
@@ -1,7 +1,7 @@
 /*
 :name: number_test_36
 :description: Test
-:should_fail: 0
+:should_fail: 1
 :tags: 5.6.4 5.7.1 5.7.2
 */
 parameter int foo = 32'dZ;


### PR DESCRIPTION
IEEE 1800-2017 does not allow `x`, `z`, or `?` in decimal digits:
```
decimal_digit ::= 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9
binary_digit ::= x_digit | z_digit | 0 | 1
octal_digit ::= x_digit | z_digit | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7
hex_digit ::= x_digit | z_digit | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | a | b | c | d | e | f | A | B | C | D | E | F
```