### PR TITLE
No parenthesis in conditional expression

### DIFF
--- a/tests/chapter-12/12.6.3--conditional_pattern.sv
+++ b/tests/chapter-12/12.6.3--conditional_pattern.sv
@@ -23,6 +23,6 @@ module case_tb ();
 	bit [3:0] val;
 
 	initial begin
-          val = (tmp matches tagged a '{4'b01zx, .v}) ? 1 : 2;
+          val = tmp matches tagged a '{4'b01zx, .v} ? 1 : 2;
 	end
 endmodule


### PR DESCRIPTION
`cond_predicate` of conditional expression can't include parenthesis.

```
conditional_expression ::= cond_predicate ? { attribute_instance } expression : expression
cond_predicate ::= expression_or_cond_pattern { &&& expression_or_cond_pattern }
expression_or_cond_pattern ::= expression | cond_pattern
cond_pattern ::= expression matches pattern
```