### PR TITLE
Fix data_type of typedef

### DIFF
--- a/tests/chapter-6/6.18--typedef.sv
+++ b/tests/chapter-6/6.18--typedef.sv
@@ -5,7 +5,7 @@
 :tags: 6.18
 */
 module top();
-	typedef wire wire_t;
+	typedef logic logic_t;
 
-	wire_t a;
+	logic_t a;
 endmodule


### PR DESCRIPTION
`typedef` must take `data_type`, but `wire` is `net_type`.

```
type_declaration ::= typedef data_type type_identifier { variable_dimension } ;
```

