### PR TITLE
tools: sv2v: fix include directories flag

### DIFF
--- a/tools/runners/Sv2v_zachjs.py
+++ b/tools/runners/Sv2v_zachjs.py
@@ -11,6 +11,6 @@ class Sv2v_zachjs(BaseRunner):
         self.cmd = [self.executable]
 
         for incdir in params['incdirs']:
-            self.cmd.append('-i' + incdir)
+            self.cmd.append('-I' + incdir)
 
         self.cmd += params['files']


### PR DESCRIPTION
It has been renamed from -i to -I and we're getting a deprecation
warning in the logs.

See: https://github.com/zachjs/sv2v/commit/c0e38f793d0677f91d363bf519e7c4fa65d2bd44

Signed-off-by: Tomasz Gorochowik <tgorochowik@antmicro.com>