### PR TITLE
report: don't omit tags missing from lrm.conf

### DIFF
--- a/tools/sv-report
+++ b/tools/sv-report
@@ -220,7 +220,7 @@ logger.info("Generating {} from log files in '{}'".format(args.out, args.logs))
 data = {}
 
 for tag in database:
-    tag_usage[tag] = 0
+    tag_usage[tag] = False
 
 
 def collect_logs(runner_name):
@@ -228,7 +228,7 @@ def collect_logs(runner_name):
     runner_tag_usage = {}
 
     for tag in database:
-        runner_tag_usage[tag] = 0
+        runner_tag_usage[tag] = False
 
     # all tests info
     runner_data["tests"] = {}
@@ -312,12 +312,12 @@ def collect_logs(runner_name):
         for _, test in tests.items():
             for tag in test["tags"].split(" "):
                 try:
-                    runner_tag_usage[tag] += 1
+                    runner_tag_usage[tag] = True
                     tags[tag]["status"].append(test["status"])
                 except KeyError:
                     logger.warning("Tag not present in the database: " + tag)
                     database[tag] = ''
-                    runner_tag_usage[tag] = 1
+                    runner_tag_usage[tag] = True
                     tags[tag] = {}
                     tags[tag]["status"] = test["status"]
                     continue
@@ -347,12 +347,16 @@ results = pool.map(collect_logs, runner_names)
 
 for r, d in zip(runner_names, results):
     data[r] = d[0]
-    tag_usage = {**tag_usage, **d[1]}
+    for tag in d[1]:
+        if not tag in database:
+            database[tag] = ''
+        if not tag_usage.get(tag, False):
+            tag_usage[tag] = d[1][tag]
 
 pool.close()
 
 for tag in tag_usage:
-    if tag_usage[tag] == 0:
+    if not tag_usage[tag]:
         del database[tag]
 
 csv_header = ['name', 'files', 'tags']


### PR DESCRIPTION
Report generator seems to again require tags to be defined in `lrm.conf` before including them in the report file. This PR aims to fix that and to allow to use tags not defined in the configuration file.