### PR TITLE
Small UI tweaks.

### DIFF
--- a/conf/report/code.css
+++ b/conf/report/code.css
@@ -1,3 +1,7 @@
+body {
+    font-family: monospace;
+}
+
 .highlight .hll { background-color: #ffffcc }
 .highlight .c { color: #228B22 } /* Comment */
 .highlight .err { color: #a61717; background-color: #e3d2d2 } /* Error */

--- a/conf/report/log-template.html
+++ b/conf/report/log-template.html
@@ -1,7 +1,12 @@
-<pre>
-<h3>
-<a href="{{runner_url}}" target="_blank">{{runner}}</a>
-</h3>
+<head>
+  <style>
+    .test-failed { background-color: #ffaaaa; }
+    .test-passed { background-color: #aaffaa; }
+  </style>
+</head>
+<body>
+<h3><a href="{{runner_url}}" target="_blank">{{runner}}</a></h3>
+<pre class="{{status}}">
 description: {{description|e}}
 should_fail: {{should_fail|e}}
 tags: {{tags|e}}
@@ -9,7 +14,8 @@ incdirs: {{incdirs|e}}
 top_module: {{top_module|e}}
 files: {{file_urls}}
 time_elapsed: {{'%0.3f'| format(time_elapsed|float)}}s
-
-{{log_urls}}
-
 </pre>
+<pre>
+{{log_urls}}
+</pre>
+</body>

--- a/conf/report/report-template.html
+++ b/conf/report/report-template.html
@@ -114,21 +114,21 @@
         </tr>
       {% endfor %}
       <tfoot>
-        <tr>
-          <th class="report_table_info" colspan="2"> Total tests passed: </th>
+        <tr class="report_summary_row">
+          <th class="report_summary_header" colspan="2"> Total tests passed: </th>
 
           {% for tool, tooldata in report|dictsort %}
           <th class="report_table_result" title="{{ tool.lower() }}" > {{ report[tool]["total"]["tests"] }}/{{ report[tool]["tests"].keys()|length }}</th>
           {% endfor %}
         </tr>
-        <tr>
-          <th class="report_table_info" colspan="2"> Total tags passed: </th>
+        <tr class="report_summary_row">
+          <th class="report_summary_header" colspan="2"> Total tags passed: </th>
           {% for tool, tooldata in report|dictsort %}
           <th class="report_table_result" title="{{ tool.lower() }}" > {{ report[tool]["total"]["tags"]}}/{{ database.keys()|length}}</th>
           {% endfor %}
         </tr>
-        <tr>
-          <th class="report_table_info" colspan="2"> Total time elapsed: </th>
+        <tr class="report_summary_row">
+          <th class="report_summary_header" colspan="2"> Total time elapsed: </th>
           {% for tool in report %}
           <th class="report_table_result" title="{{ tool.lower() }}" >
             {{'%0.2f'| format(report[tool]["time_elapsed"]|float)}}s </th>

--- a/conf/report/report.css
+++ b/conf/report/report.css
@@ -1,3 +1,7 @@
+body {
+  font-family: sans-serif;
+}
+
 table.dataTable {
   width: auto;
   table-layout: fixed;
@@ -10,16 +14,24 @@ table.dataTable tfoot th {
 
 .report_table_tag {
   text-align: left;
-  width: 50px;
+  width: 8em;
 }
 
 .report_table_info {
   text-overflow: ellipsis;
   white-space: nowrap;
-  text-align: left;
+  text-align: right;
   overflow: hidden;
-  max-width: 150px;
-  width: 150px;
+  width: 30em;
+  max-width: 30em;
+}
+
+.report_summary_row {
+  background-color: lightgray;
+}
+
+.report_summary_header {
+  text-align: right;
 }
 
 .ui-widget-shadow {
@@ -48,7 +60,7 @@ table.dataTable tfoot th {
 }
 
 .test-cell-selected {
-  border: 1px solid black;
+  outline: 3px solid blue;
   filter: brightness(95%);
   font-weight: bold;
 }
@@ -129,7 +141,7 @@ table.dataTable tfoot th {
   float: left;
 }
 .logtab-btn-selected {
-  border: 2px solid black;
+  border: 2px solid blue;
   font-weight: bold;
 }
 .logfile-tab {

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -280,6 +280,14 @@ def collect_logs(runner_name):
             tests[t_id]["log"] = f.read()
             tests[t_id]["fname"] = os.path.join('logs', t_id + '.html')
 
+            tool_should_fail = tests[t_id]["should_fail"] == "1"
+            tool_rc = int(tests[t_id]["rc"])
+            tool_failed = (tool_rc != 0)
+            if tool_rc >= 126 or tool_should_fail != tool_failed:
+                tests[t_id]["status"] = "test-failed"
+            else:
+                tests[t_id]["status"] = "test-passed"
+
             t_html = t.replace(
                 args.logs, os.path.join(os.path.dirname(args.out), "logs"))
             os.makedirs(os.path.dirname(t_html), exist_ok=True)
@@ -302,37 +310,16 @@ def collect_logs(runner_name):
 
         # generate tags summary
         for _, test in tests.items():
-            # check if test has passed
-            passed = True
-
-            tool_should_fail = test["should_fail"] == "1"
-            tool_failed = test["rc"] != "0"
-
-            if int(test["rc"]) >= 126 or tool_should_fail != tool_failed:
-                passed = False
-
-            status = "test-" + ("passed" if passed else "failed")
-            test["status"] = status
-
-            if passed:
-                logger.debug(
-                    "{} passed {} in {}".format(
-                        runner_name, test["tags"], test["name"]))
-            else:
-                logger.debug(
-                    "{} failed {} in {}".format(
-                        runner_name, test["tags"], test["name"]))
-
             for tag in test["tags"].split(" "):
                 try:
                     runner_tag_usage[tag] += 1
-                    tags[tag]["status"].append(status)
+                    tags[tag]["status"].append(test["status"])
                 except KeyError:
                     logger.warning("Tag not present in the database: " + tag)
                     database[tag] = ''
                     runner_tag_usage[tag] = 1
                     tags[tag] = {}
-                    tags[tag]["status"] = [status]
+                    tags[tag]["status"] = test["status"]
                     continue
 
         for tag in tags:


### PR DESCRIPTION
 * Highlight the current grid-box more visibly with a thicker and blue box.
 * Make the main-grid fill the width of the browser. Previously, it was only using the center, leaving a lot of whitespace around.
 * Highlight the summary line with some gray background.
 * Show the header of the logfile in green/red for faster visual parsing (moved status calculation before logfile html generation in sv-report for that; removed some older debug logs in the course of that)