### PR TITLE
Fix order of "Total time elapsed"

### DIFF
--- a/conf/report/report-template.html
+++ b/conf/report/report-template.html
@@ -129,7 +129,7 @@
         </tr>
         <tr class="report_summary_row">
           <th class="report_summary_header" colspan="2"> Total time elapsed: </th>
-          {% for tool in report %}
+          {% for tool, tooldata in report|dictsort %}
           <th class="report_table_result" title="{{ tool.lower() }}" >
             {{'%0.2f'| format(report[tool]["time_elapsed"]|float)}}s </th>
           {% endfor %}


### PR DESCRIPTION
The column of "Total time elapsed" has the wrong order than other columns.