### PR TITLE
Fix font

### DIFF
--- a/conf/report/code.css
+++ b/conf/report/code.css
@@ -1,5 +1,9 @@
 body {
-    font-family: monospace;
+    font-family: "Courier New", Consolas, monospace;
+    font-size: 80%
+}
+pre {
+    font-family: "Courier New", Consolas, monospace;
 }
 
 .highlight .hll { background-color: #ffffcc }

--- a/conf/report/log-template.html
+++ b/conf/report/log-template.html
@@ -1,5 +1,6 @@
 <head>
   <style>
+    .log { font-family: "Courier New", Consolas, monospace; font-size: 80%; }
     .test-failed { background-color: #ffaaaa; }
     .test-passed { background-color: #aaffaa; }
   </style>
@@ -15,7 +16,7 @@ top_module: {{top_module|e}}
 files: {{file_urls}}
 time_elapsed: {{'%0.3f'| format(time_elapsed|float)}}s
 </pre>
-<pre>
+<pre class="log">
 {{log_urls}}
 </pre>
 </body>


### PR DESCRIPTION
Some environments can't show monospaced font by `font-family: monospace`.
Additionally some tools expect the log is shown by monospaced font like below:

```
%Warning-STMTDLY: third_party/tools/yosys/tests/asicworld/code_hdl_models_arbiter_tb.v:15: Unsupported: Ignoring delay on this delayed statement.
always #1 clk = ~clk;
       ^
```