### PR TITLE
Add support for simulator runners

### DIFF
--- a/conf/report/log-template.html
+++ b/conf/report/log-template.html
@@ -13,6 +13,8 @@ should_fail: {{should_fail|e}}
 tags: {{tags|e}}
 incdirs: {{incdirs|e}}
 top_module: {{top_module|e}}
+type: {{type|e}}
+mode: {{mode|e}}
 files: {{file_urls}}
 time_elapsed: {{'%0.3f'| format(time_elapsed|float)}}s
 </pre>

--- a/conf/runners/vmain.cpp
+++ b/conf/runners/vmain.cpp
@@ -1,0 +1,19 @@
+/*
+ * Top level simulation driver for use with verilator
+ */
+
+#include <verilated.h>
+#include <Vtop.h>
+
+int main(int argc, char *argv[]) {
+	Vtop *top = new Vtop;
+
+	for (int i = 0; i < 1000 && !Verilated::gotFinish(); i++)
+		top->eval();
+
+	top->final();
+
+	delete top;
+
+	return 0;
+}

--- a/tests/chapter-11/11.10.1--string_compare.sv
+++ b/tests/chapter-11/11.10.1--string_compare.sv
@@ -3,6 +3,7 @@
 :description: string comparison test
 :should_fail: 0
 :tags: 11.10.1
+:type: simulation parsing
 */
 module top();
 
@@ -12,7 +13,7 @@ bit [8*14:1] b;
 initial begin
 	a = "Test";
 	b = "Test";
-	$display(a == b);
+	$display(":assert:('%s' == '%s')", a, b);
 end
 
 endmodule

--- a/tests/chapter-11/11.10.1--string_copy.sv
+++ b/tests/chapter-11/11.10.1--string_copy.sv
@@ -3,6 +3,7 @@
 :description: string copy test
 :should_fail: 0
 :tags: 11.10.1
+:type: simulation parsing
 */
 module top();
 
@@ -12,7 +13,7 @@ bit [8*14:1] b;
 initial begin
 	a = "Test";
 	b = a;
-	$display(b);
+	$display(":assert:('%s' == '%s')", a, b);
 end
 
 endmodule

--- a/tests/chapter-11/11.4.12.2--string_concat_op.sv
+++ b/tests/chapter-11/11.4.12.2--string_concat_op.sv
@@ -3,14 +3,15 @@
 :description: string concatenation operator test
 :should_fail: 0
 :tags: 11.4.12.2
+:type: simulation parsing
 */
 module top();
 
 string str;
 
 initial begin
-	str = {"Hello", " ", "World", "!"};
-	$display(str);
+	str = {"Hello", "_", "World", "!"};
+	$display(":assert:('%s' == 'Hello_World!')", str);
 end
 
 endmodule

--- a/tests/chapter-11/11.4.12.2--string_repl_op.sv
+++ b/tests/chapter-11/11.4.12.2--string_repl_op.sv
@@ -3,14 +3,15 @@
 :description: string replication operator test
 :should_fail: 0
 :tags: 11.4.12.2
+:type: simulation parsing
 */
 module top();
 
 string str;
 
 initial begin
-	str = {4{"test "}};
-	$display(str);
+	str = {4{"test"}};
+	$display(":assert:('%s' == 'testtesttesttest')", str);
 end
 
 endmodule

--- a/tests/chapter-12/12.8--break.sv
+++ b/tests/chapter-12/12.8--break.sv
@@ -3,14 +3,15 @@
 :description: A module testing break statement
 :should_fail: 0
 :tags: 12.8
+:type: simulation parsing
 */
 module jump_tb ();
 	initial begin
-		for (int i = 0; i < 256; i++)begin
-			$display(i);
+		int i;
+		for (i = 0; i < 256; i++)begin
 			if(i > 100)
 				break;
 		end
-
+		$display(":assert:(%d == 101)", i);
 	end
 endmodule

--- a/tests/chapter-12/12.8--continue.sv
+++ b/tests/chapter-12/12.8--continue.sv
@@ -3,13 +3,14 @@
 :description: A module testing continue statement
 :should_fail: 0
 :tags: 12.8
+:type: simulation parsing
 */
 module jump_tb ();
 	initial begin
 		for (int i = 0; i < 256; i++)begin
-			if(i < 100)
+			if(i < 255)
 				continue;
-			$display(i);
+			$display(":assert:(%d == 255)", i);
 		end
 
 	end

--- a/tests/chapter-6/6.13--void.sv
+++ b/tests/chapter-6/6.13--void.sv
@@ -3,10 +3,11 @@
 :description: void type tests
 :should_fail: 0
 :tags: 6.13
+:type: simulation parsing
 */
 module top();
 	function void fun();
-		$display("void fun");
+		$display(":assert:(True)");
 	endfunction
 
 	initial

--- a/tests/chapter-7/arrays/associative/alloc.sv
+++ b/tests/chapter-7/arrays/associative/alloc.sv
@@ -3,6 +3,7 @@
 :description: Test associative arrays elements allocation
 :should_fail: 0
 :tags: 7.8.7 7.8 7.9.1
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/associative/arguments.sv
+++ b/tests/chapter-7/arrays/associative/arguments.sv
@@ -3,6 +3,7 @@
 :description: Test passing associative array as arugments support
 :should_fail: 0
 :tags: 7.9.10 7.8
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/associative/assignment.sv
+++ b/tests/chapter-7/arrays/associative/assignment.sv
@@ -3,6 +3,7 @@
 :description: Test associative arrays assignment support
 :should_fail: 0
 :tags: 7.9.9 7.8
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/associative/literals.sv
+++ b/tests/chapter-7/arrays/associative/literals.sv
@@ -3,6 +3,7 @@
 :description: Test associative arrays literals support
 :should_fail: 0
 :tags: 7.9.11 7.8
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/associative/locator-methods/find-first-index.sv
+++ b/tests/chapter-7/arrays/associative/locator-methods/find-first-index.sv
@@ -3,6 +3,7 @@
 :description: Test support of array locator methods
 :should_fail: 0
 :tags: 7.12.1 7.12 7.10
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/associative/locator-methods/find-first.sv
+++ b/tests/chapter-7/arrays/associative/locator-methods/find-first.sv
@@ -3,6 +3,7 @@
 :description: Test support of array locator methods
 :should_fail: 0
 :tags: 7.12.1 7.12 7.10
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/associative/locator-methods/find-index.sv
+++ b/tests/chapter-7/arrays/associative/locator-methods/find-index.sv
@@ -3,6 +3,7 @@
 :description: Test support of array locator methods
 :should_fail: 0
 :tags: 7.12.1 7.12 7.10
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/associative/locator-methods/find-last-index.sv
+++ b/tests/chapter-7/arrays/associative/locator-methods/find-last-index.sv
@@ -3,6 +3,7 @@
 :description: Test support of array locator methods
 :should_fail: 0
 :tags: 7.12.1 7.12 7.10
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/associative/locator-methods/find-last.sv
+++ b/tests/chapter-7/arrays/associative/locator-methods/find-last.sv
@@ -3,6 +3,7 @@
 :description: Test support of array locator methods
 :should_fail: 0
 :tags: 7.12.1 7.12 7.10
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/associative/locator-methods/find.sv
+++ b/tests/chapter-7/arrays/associative/locator-methods/find.sv
@@ -3,6 +3,7 @@
 :description: Test support of array locator methods
 :should_fail: 0
 :tags: 7.12.1 7.12 7.10
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/associative/locator-methods/max.sv
+++ b/tests/chapter-7/arrays/associative/locator-methods/max.sv
@@ -3,6 +3,7 @@
 :description: Test support of array locator methods
 :should_fail: 0
 :tags: 7.12.1 7.12 7.10
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/associative/locator-methods/min.sv
+++ b/tests/chapter-7/arrays/associative/locator-methods/min.sv
@@ -3,6 +3,7 @@
 :description: Test support of array locator methods
 :should_fail: 0
 :tags: 7.12.1 7.12 7.10
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/associative/locator-methods/unique-index.sv
+++ b/tests/chapter-7/arrays/associative/locator-methods/unique-index.sv
@@ -3,6 +3,7 @@
 :description: Test support of array locator methods
 :should_fail: 0
 :tags: 7.12.1 7.12 7.10 7.12.2
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/associative/locator-methods/unique.sv
+++ b/tests/chapter-7/arrays/associative/locator-methods/unique.sv
@@ -3,6 +3,7 @@
 :description: Test support of array locator methods
 :should_fail: 0
 :tags: 7.12.1 7.12 7.10 7.12.2
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/associative/methods/delete.sv
+++ b/tests/chapter-7/arrays/associative/methods/delete.sv
@@ -3,6 +3,7 @@
 :description: Test support of associative arrays methods (delete)
 :should_fail: 0
 :tags: 7.9.2 7.9
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/associative/methods/exists.sv
+++ b/tests/chapter-7/arrays/associative/methods/exists.sv
@@ -3,6 +3,7 @@
 :description: Test support of associative arrays methods (exists)
 :should_fail: 0
 :tags: 7.9.3 7.9
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/associative/methods/first.sv
+++ b/tests/chapter-7/arrays/associative/methods/first.sv
@@ -3,6 +3,7 @@
 :description: Test support of associative arrays methods (first)
 :should_fail: 0
 :tags: 7.9.4 7.9
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/associative/methods/last.sv
+++ b/tests/chapter-7/arrays/associative/methods/last.sv
@@ -3,6 +3,7 @@
 :description: Test support of associative arrays methods (last)
 :should_fail: 0
 :tags: 7.9.5 7.9
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/associative/methods/next.sv
+++ b/tests/chapter-7/arrays/associative/methods/next.sv
@@ -3,6 +3,7 @@
 :description: Test support of associative arrays methods (next)
 :should_fail: 0
 :tags: 7.9.6 7.9
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/associative/methods/num.sv
+++ b/tests/chapter-7/arrays/associative/methods/num.sv
@@ -3,6 +3,7 @@
 :description: Test support of associative arrays methods (num)
 :should_fail: 0
 :tags: 7.9.1 7.9
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/associative/methods/prev.sv
+++ b/tests/chapter-7/arrays/associative/methods/prev.sv
@@ -3,6 +3,7 @@
 :description: Test support of associative arrays methods (prev)
 :should_fail: 0
 :tags: 7.9.7 7.9
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/associative/methods/size.sv
+++ b/tests/chapter-7/arrays/associative/methods/size.sv
@@ -3,6 +3,7 @@
 :description: Test support of associative arrays methods (size)
 :should_fail: 0
 :tags: 7.9.1 7.9
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/associative/methods/traversal.sv
+++ b/tests/chapter-7/arrays/associative/methods/traversal.sv
@@ -3,6 +3,7 @@
 :description: Test support of associative arrays methods
 :should_fail: 0
 :tags: 7.9.8 7.9
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/associative/nonexistent.sv
+++ b/tests/chapter-7/arrays/associative/nonexistent.sv
@@ -3,6 +3,7 @@
 :description: Test access to nonexistent associative array element
 :should_fail: 0
 :tags: 7.8.6 7.9.1
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/dynamic/op-delete.sv
+++ b/tests/chapter-7/arrays/dynamic/op-delete.sv
@@ -3,6 +3,7 @@
 :description: Test dynamic arrays operator delete support
 :should_fail: 0
 :tags: 7.5.3
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/dynamic/op-new.sv
+++ b/tests/chapter-7/arrays/dynamic/op-new.sv
@@ -3,6 +3,7 @@
 :description: Test dynamic arrays operator new support
 :should_fail: 0
 :tags: 7.5.1
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/dynamic/op-size.sv
+++ b/tests/chapter-7/arrays/dynamic/op-size.sv
@@ -3,6 +3,7 @@
 :description: Test dynamic arrays operator size support
 :should_fail: 0
 :tags: 7.5.2
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/multidimensional/copy.sv
+++ b/tests/chapter-7/arrays/multidimensional/copy.sv
@@ -3,6 +3,7 @@
 :description: Test multidimensional word copy
 :should_fail: 0
 :tags: 7.4.5
+:type: simulation parsing
 */
 
 module top ();

--- a/tests/chapter-7/arrays/multidimensional/subarrays.sv
+++ b/tests/chapter-7/arrays/multidimensional/subarrays.sv
@@ -3,6 +3,7 @@
 :description: Test multidimensional subarrays assignments
 :should_fail: 0
 :tags: 7.4.5
+:type: simulation parsing
 */
 
 module top ();

--- a/tests/chapter-7/arrays/packed/equality.sv
+++ b/tests/chapter-7/arrays/packed/equality.sv
@@ -3,6 +3,7 @@
 :description: Test packed arrays operations support (equality)
 :should_fail: 0
 :tags: 7.4.3
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/packed/onebit.sv
+++ b/tests/chapter-7/arrays/packed/onebit.sv
@@ -3,6 +3,7 @@
 :description: Test packed arrays operations support (one bit)
 :should_fail: 0
 :tags: 7.4.3
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/packed/operations.sv
+++ b/tests/chapter-7/arrays/packed/operations.sv
@@ -3,6 +3,7 @@
 :description: Test packed arrays operations support (R & W)
 :should_fail: 0
 :tags: 7.4.3
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/packed/querying-functions/dimensions.sv
+++ b/tests/chapter-7/arrays/packed/querying-functions/dimensions.sv
@@ -3,6 +3,7 @@
 :description: Test quering functions support on packed arrays
 :should_fail: 0
 :tags: 7.11 7.4.1
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/packed/querying-functions/high.sv
+++ b/tests/chapter-7/arrays/packed/querying-functions/high.sv
@@ -3,6 +3,7 @@
 :description: Test quering functions support on packed arrays
 :should_fail: 0
 :tags: 7.11 7.4.1
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/packed/querying-functions/increment.sv
+++ b/tests/chapter-7/arrays/packed/querying-functions/increment.sv
@@ -3,6 +3,7 @@
 :description: Test quering functions support on packed arrays
 :should_fail: 0
 :tags: 7.11 7.4.1
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/packed/querying-functions/left.sv
+++ b/tests/chapter-7/arrays/packed/querying-functions/left.sv
@@ -3,6 +3,7 @@
 :description: Test quering functions support on packed arrays
 :should_fail: 0
 :tags: 7.11 7.4.1
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/packed/querying-functions/low.sv
+++ b/tests/chapter-7/arrays/packed/querying-functions/low.sv
@@ -3,6 +3,7 @@
 :description: Test quering functions support on packed arrays
 :should_fail: 0
 :tags: 7.11 7.4.1
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/packed/querying-functions/right.sv
+++ b/tests/chapter-7/arrays/packed/querying-functions/right.sv
@@ -3,6 +3,7 @@
 :description: Test quering functions support on packed arrays
 :should_fail: 0
 :tags: 7.11 7.4.1
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/packed/querying-functions/size.sv
+++ b/tests/chapter-7/arrays/packed/querying-functions/size.sv
@@ -3,6 +3,7 @@
 :description: Test quering functions support on packed arrays
 :should_fail: 0
 :tags: 7.11 7.4.1
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/packed/querying-functions/unpacked-dimensions.sv
+++ b/tests/chapter-7/arrays/packed/querying-functions/unpacked-dimensions.sv
@@ -3,6 +3,7 @@
 :description: Test quering functions support on packed arrays
 :should_fail: 0
 :tags: 7.11 7.4.1
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/packed/slice-equality.sv
+++ b/tests/chapter-7/arrays/packed/slice-equality.sv
@@ -3,6 +3,7 @@
 :description: Test packed arrays operations support (slice equality)
 :should_fail: 0
 :tags: 7.4.3
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/packed/slice.sv
+++ b/tests/chapter-7/arrays/packed/slice.sv
@@ -3,6 +3,7 @@
 :description: Test packed arrays operations support (R&W slice)
 :should_fail: 0
 :tags: 7.4.3
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/packed/treat-as-integer.sv
+++ b/tests/chapter-7/arrays/packed/treat-as-integer.sv
@@ -3,6 +3,7 @@
 :description: Test packed arrays operations support (treat array as integer)
 :should_fail: 0
 :tags: 7.4.3
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/packed/variable-slice-zero.sv
+++ b/tests/chapter-7/arrays/packed/variable-slice-zero.sv
@@ -3,6 +3,7 @@
 :description: Test packed arrays operations support (Variable slice)
 :should_fail: 1
 :tags: 7.4.3
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/packed/variable-slice.sv
+++ b/tests/chapter-7/arrays/packed/variable-slice.sv
@@ -3,6 +3,7 @@
 :description: Test packed arrays operations support (Variable slice)
 :should_fail: 0
 :tags: 7.4.3 7.4.6
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/unpacked/assignments.sv
+++ b/tests/chapter-7/arrays/unpacked/assignments.sv
@@ -3,6 +3,7 @@
 :description: Test unpacked arrays assignments
 :should_fail: 0
 :tags: 7.6 7.4.2
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/unpacked/equality.sv
+++ b/tests/chapter-7/arrays/unpacked/equality.sv
@@ -3,6 +3,7 @@
 :description: Test unpacked arrays operations support (equality)
 :should_fail: 0
 :tags: 7.4.3
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/unpacked/index.sv
+++ b/tests/chapter-7/arrays/unpacked/index.sv
@@ -3,6 +3,7 @@
 :description: Test support of unpacked arrays index querying method
 :should_fail: 0
 :tags: 7.12.4 7.4.2 7.10 7.12.1
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/unpacked/onebit.sv
+++ b/tests/chapter-7/arrays/unpacked/onebit.sv
@@ -3,6 +3,7 @@
 :description: Test unpacked arrays operations support (one bit)
 :should_fail: 0
 :tags: 7.4.3
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/unpacked/operations.sv
+++ b/tests/chapter-7/arrays/unpacked/operations.sv
@@ -3,6 +3,7 @@
 :description: Test unpacked arrays operations support (R & W)
 :should_fail: 0
 :tags: 7.4.3
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/unpacked/ordering-methods/reverse.sv
+++ b/tests/chapter-7/arrays/unpacked/ordering-methods/reverse.sv
@@ -3,6 +3,7 @@
 :description: Test support of reverse method on unpacked arrays
 :should_fail: 0
 :tags: 7.12.2 7.4.2
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/unpacked/ordering-methods/rsort.sv
+++ b/tests/chapter-7/arrays/unpacked/ordering-methods/rsort.sv
@@ -3,6 +3,7 @@
 :description: Test support of rsort method on unpacked arrays
 :should_fail: 0
 :tags: 7.12.2 7.4.2
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/unpacked/ordering-methods/shuffle.sv
+++ b/tests/chapter-7/arrays/unpacked/ordering-methods/shuffle.sv
@@ -3,6 +3,7 @@
 :description: Test support of shuffle method on unpacked arrays
 :should_fail: 0
 :tags: 7.12.2 7.4.2
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/unpacked/ordering-methods/sort.sv
+++ b/tests/chapter-7/arrays/unpacked/ordering-methods/sort.sv
@@ -3,6 +3,7 @@
 :description: Test support of sort method on unpacked arrays
 :should_fail: 0
 :tags: 7.12.2 7.4.2
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/unpacked/reduction-methods/and.sv
+++ b/tests/chapter-7/arrays/unpacked/reduction-methods/and.sv
@@ -3,6 +3,7 @@
 :description: Test support of unpacked arrays reduction method and
 :should_fail: 0
 :tags: 7.12.3 7.4.2
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/unpacked/reduction-methods/or.sv
+++ b/tests/chapter-7/arrays/unpacked/reduction-methods/or.sv
@@ -3,6 +3,7 @@
 :description: Test support of unpacked arrays reduction method or
 :should_fail: 0
 :tags: 7.12.3 7.4.2
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/unpacked/reduction-methods/product.sv
+++ b/tests/chapter-7/arrays/unpacked/reduction-methods/product.sv
@@ -3,6 +3,7 @@
 :description: Test support of unpacked arrays reduction method product
 :should_fail: 0
 :tags: 7.12.3 7.4.2
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/unpacked/reduction-methods/sum.sv
+++ b/tests/chapter-7/arrays/unpacked/reduction-methods/sum.sv
@@ -3,6 +3,7 @@
 :description: Test support of unpacked arrays reduction method sum
 :should_fail: 0
 :tags: 7.12.3 7.4.2
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/unpacked/reduction-methods/xor.sv
+++ b/tests/chapter-7/arrays/unpacked/reduction-methods/xor.sv
@@ -3,6 +3,7 @@
 :description: Test support of unpacked arrays reduction method xor
 :should_fail: 0
 :tags: 7.12.3 7.4.2
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/unpacked/slice-equality.sv
+++ b/tests/chapter-7/arrays/unpacked/slice-equality.sv
@@ -3,6 +3,7 @@
 :description: Test unpacked arrays operations support (slice equality)
 :should_fail: 0
 :tags: 7.4.3
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/unpacked/slice.sv
+++ b/tests/chapter-7/arrays/unpacked/slice.sv
@@ -3,6 +3,7 @@
 :description: Test unpacked arrays operations support (R&W slice)
 :should_fail: 0
 :tags: 7.4.3
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/unpacked/subroutines.sv
+++ b/tests/chapter-7/arrays/unpacked/subroutines.sv
@@ -3,6 +3,7 @@
 :description: Test support of arrays as arugments to subroutines
 :should_fail: 0
 :tags: 7.7 7.4.2
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/arrays/unpacked/variable-slice.sv
+++ b/tests/chapter-7/arrays/unpacked/variable-slice.sv
@@ -3,6 +3,7 @@
 :description: Test packed arrays operations support (Variable slice)
 :should_fail: 0
 :tags: 7.4.3 7.4.6
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/memories/read-write.sv
+++ b/tests/chapter-7/memories/read-write.sv
@@ -3,6 +3,7 @@
 :description: Test memories read-write support
 :should_fail: 0
 :tags: 7.4.4
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/queues/bounded.sv
+++ b/tests/chapter-7/queues/bounded.sv
@@ -3,6 +3,7 @@
 :description: Test bounded queues support
 :should_fail: 0
 :tags: 7.10.5 7.10 7.10.2.7 7.10.2.1
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/queues/delete.sv
+++ b/tests/chapter-7/queues/delete.sv
@@ -3,6 +3,7 @@
 :description: Test queues delete function support
 :should_fail: 0
 :tags: 7.10.2.3 7.10.2
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/queues/delete_assign.sv
+++ b/tests/chapter-7/queues/delete_assign.sv
@@ -3,6 +3,7 @@
 :description: Update queue by assignment (delete)
 :should_fail: 0
 :tags: 7.10.4
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/queues/insert.sv
+++ b/tests/chapter-7/queues/insert.sv
@@ -3,6 +3,7 @@
 :description: Test queues insert function support
 :should_fail: 0
 :tags: 7.10.2.2 7.10.2
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/queues/insert_assign.sv
+++ b/tests/chapter-7/queues/insert_assign.sv
@@ -3,6 +3,7 @@
 :description: Update queue by assignment (insert)
 :should_fail: 0
 :tags: 7.10.4
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/queues/max-size.sv
+++ b/tests/chapter-7/queues/max-size.sv
@@ -3,6 +3,7 @@
 :description: Test queues size support
 :should_fail: 0
 :tags: 7.10.1 7.10.2
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/queues/persistence.sv
+++ b/tests/chapter-7/queues/persistence.sv
@@ -3,6 +3,7 @@
 :description: Test status of persistence of references to elements of queue
 :should_fail: 0
 :tags: 7.10.3
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/queues/pop_back.sv
+++ b/tests/chapter-7/queues/pop_back.sv
@@ -3,6 +3,7 @@
 :description: Test queues pop_back function support
 :should_fail: 0
 :tags: 7.10.2.5 7.10.2
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/queues/pop_back_assing.sv
+++ b/tests/chapter-7/queues/pop_back_assing.sv
@@ -3,6 +3,7 @@
 :description: Update queue by assignment (pop_back)
 :should_fail: 0
 :tags: 7.10.4
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/queues/pop_front.sv
+++ b/tests/chapter-7/queues/pop_front.sv
@@ -3,6 +3,7 @@
 :description: Test queues pop_front function support
 :should_fail: 0
 :tags: 7.10.2.4 7.10.2
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/queues/pop_front_assign.sv
+++ b/tests/chapter-7/queues/pop_front_assign.sv
@@ -3,6 +3,7 @@
 :description: Update queue by assignment (pop_front)
 :should_fail: 0
 :tags: 7.10.4
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/queues/push_back.sv
+++ b/tests/chapter-7/queues/push_back.sv
@@ -3,6 +3,7 @@
 :description: Test queues push_back function support
 :should_fail: 0
 :tags: 7.10.2.7 7.10.2
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/queues/push_back_assign.sv
+++ b/tests/chapter-7/queues/push_back_assign.sv
@@ -3,6 +3,7 @@
 :description: Update queue by assignment (push_back)
 :should_fail: 0
 :tags: 7.10.4
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/queues/push_front.sv
+++ b/tests/chapter-7/queues/push_front.sv
@@ -3,6 +3,7 @@
 :description: Test queues push_front function support
 :should_fail: 0
 :tags: 7.10.2.6 7.10.2
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/queues/push_front_assign.sv
+++ b/tests/chapter-7/queues/push_front_assign.sv
@@ -3,6 +3,7 @@
 :description: Update queue by assignment (push_front)
 :should_fail: 0
 :tags: 7.10.4
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/queues/size.sv
+++ b/tests/chapter-7/queues/size.sv
@@ -3,6 +3,7 @@
 :description: Test queues size support
 :should_fail: 0
 :tags: 7.10.2.1 7.10.2
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/queues/slice.sv
+++ b/tests/chapter-7/queues/slice.sv
@@ -3,6 +3,7 @@
 :description: Test queues slice support
 :should_fail: 0
 :tags: 7.10.1 7.10.2
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/structures/packed/basic.sv
+++ b/tests/chapter-7/structures/packed/basic.sv
@@ -3,6 +3,7 @@
 :description: Test packed structures support
 :should_fail: 0
 :tags: 7.2.1 7.2 7.1
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/structures/packed/signed.sv
+++ b/tests/chapter-7/structures/packed/signed.sv
@@ -3,6 +3,7 @@
 :description: Test packed and signed structures support
 :should_fail: 0
 :tags: 7.2.1 7.2
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/structures/packed/unsigned.sv
+++ b/tests/chapter-7/structures/packed/unsigned.sv
@@ -3,6 +3,7 @@
 :description: Test packed and unsigned structures support
 :should_fail: 0
 :tags: 7.2.1 7.2
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/structures/unpacked/basic.sv
+++ b/tests/chapter-7/structures/unpacked/basic.sv
@@ -3,6 +3,7 @@
 :description: Test unpacked structures support
 :should_fail: 0
 :tags: 7.2 7.1
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/structures/unpacked/default-value.sv
+++ b/tests/chapter-7/structures/unpacked/default-value.sv
@@ -3,6 +3,7 @@
 :description: Test unpacked structures members default value support
 :should_fail: 0
 :tags: 7.2.2
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/unions/basic.sv
+++ b/tests/chapter-7/unions/basic.sv
@@ -3,6 +3,7 @@
 :description: Test basic union support
 :should_fail: 0
 :tags: 7.3
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/unions/packed/basic.sv
+++ b/tests/chapter-7/unions/packed/basic.sv
@@ -3,6 +3,7 @@
 :description: Test basic union support
 :should_fail: 0
 :tags: 7.3.1
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/unions/tagged/basic.sv
+++ b/tests/chapter-7/unions/tagged/basic.sv
@@ -3,6 +3,7 @@
 :description: Test basic tagged union support
 :should_fail: 0
 :tags: 7.3.2
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-7/unions/tagged/packed.sv
+++ b/tests/chapter-7/unions/tagged/packed.sv
@@ -3,6 +3,7 @@
 :description: Test tagged packed union support
 :should_fail: 0
 :tags: 7.3.2
+:type: simulation parsing
 */
 module top ();
 

--- a/tests/chapter-8/8.26.3--type_access_implements.sv
+++ b/tests/chapter-8/8.26.3--type_access_implements.sv
@@ -3,6 +3,7 @@
 :description: access interface class type with scope resolution operator
 :should_fail: 0
 :tags: 8.26.3
+:type: simulation parsing
 */
 module class_tb ();
 	interface class ihello;
@@ -12,7 +13,7 @@ module class_tb ();
 	
 	class Hello implements ihello;
 		virtual function void hello(ihello::int_t val);
-			$display("hello world %d", val);
+			$display(":assert:(%d == 12)", val);
 		endfunction
 	endclass
 
@@ -20,6 +21,6 @@ module class_tb ();
 
 	initial begin
 		obj = new;
-		obj.hello();
+		obj.hello(12);
 	end
 endmodule

--- a/tests/chapter-8/8.26.6.1--name_conflict_resolved.sv
+++ b/tests/chapter-8/8.26.6.1--name_conflict_resolved.sv
@@ -3,6 +3,7 @@
 :description: resolved interface class method name conflict
 :should_fail: 0
 :tags: 8.26.6.1
+:type: simulation parsing
 */
 module class_tb ();
 	interface class ihello;
@@ -15,7 +16,7 @@ module class_tb ();
 	
 	class Hello implements ihello, itest;
 		virtual function void hello();
-			$display("hello world");
+			$display(":assert:(True)");
 		endfunction
 	endclass
 

--- a/tests/chapter-8/8.5--parameters.sv
+++ b/tests/chapter-8/8.5--parameters.sv
@@ -3,6 +3,7 @@
 :description: parametrized class test
 :should_fail: 0
 :tags: 8.5 8.25
+:type: simulation parsing
 */
 module class_tb ();
 	class test_cls #(parameter a = 12);
@@ -12,6 +13,6 @@ module class_tb ();
 
 	initial begin
 		test_obj = new;
-		$display(test_cls.a);
+		$display(":assert:(%d == 34)", test_cls.a);
 	end
 endmodule

--- a/tests/chapter-8/8.5--properties.sv
+++ b/tests/chapter-8/8.5--properties.sv
@@ -3,6 +3,7 @@
 :description: class properties test
 :should_fail: 0
 :tags: 8.5
+:type: simulation parsing
 */
 module class_tb ();
 	class test_cls;
@@ -16,6 +17,6 @@ module class_tb ();
 
 		test_obj.a = 12;
 
-		$display(test_obj.a);
+		$display(":assert:(%d == 12)", test_obj.a);
 	end
 endmodule

--- a/tests/chapter-8/8.7--constructor.sv
+++ b/tests/chapter-8/8.7--constructor.sv
@@ -3,6 +3,7 @@
 :description: class constructor test
 :should_fail: 0
 :tags: 8.7
+:type: simulation parsing
 */
 module class_tb ();
 	class test_cls;
@@ -15,6 +16,6 @@ module class_tb ();
 	initial begin
 		test_cls test_obj = new;
 
-		$display(test_obj.a);
+		$display(":assert:(%d == 42)", test_obj.a);
 	end
 endmodule

--- a/tests/chapter-8/8.7--constructor_param.sv
+++ b/tests/chapter-8/8.7--constructor_param.sv
@@ -3,6 +3,7 @@
 :description: class constructor with arguments test
 :should_fail: 0
 :tags: 8.7
+:type: simulation parsing
 */
 module class_tb ();
 	class test_cls;
@@ -15,6 +16,6 @@ module class_tb ();
 	initial begin
 		test_cls test_obj = new(37);
 
-		$display(test_obj.a);
+		$display(":assert:(%d == 37)", test_obj.a);
 	end
 endmodule

--- a/tests/chapter-9/9.4.2.4--event_sequence.sv
+++ b/tests/chapter-9/9.4.2.4--event_sequence.sv
@@ -3,6 +3,7 @@
 :description: sequence event test
 :should_fail: 0
 :tags: 9.4.2.4
+:type: simulation parsing
 */
 module seq_tb ();
 	wire a = 0;
@@ -19,7 +20,7 @@ module seq_tb ();
 		fork
 			begin
 				@seq y = 1;
-				$display("ok");
+				$display(":assert:(True)");
 			end
 			begin
 				a = 1;

--- a/tests/generic/preproc/preproc_test_0.sv
+++ b/tests/generic/preproc/preproc_test_0.sv
@@ -3,5 +3,6 @@
 :description: Test
 :should_fail: 0
 :tags: 5.6.4
+:type: preprocessing
 */
 `define TRUTH

--- a/tests/generic/preproc/preproc_test_1.sv
+++ b/tests/generic/preproc/preproc_test_1.sv
@@ -3,5 +3,6 @@
 :description: Test
 :should_fail: 0
 :tags: 5.6.4
+:type: preprocessing
 */
 `define FOO BAR-1

--- a/tests/generic/preproc/preproc_test_10.sv
+++ b/tests/generic/preproc/preproc_test_10.sv
@@ -3,6 +3,7 @@
 :description: Test
 :should_fail: 0
 :tags: 5.6.4
+:type: preprocessing
 */
 `define LONG_MACRO(
     a,

--- a/tests/generic/preproc/preproc_test_11.sv
+++ b/tests/generic/preproc/preproc_test_11.sv
@@ -3,6 +3,7 @@
 :description: Test
 :should_fail: 0
 :tags: 5.6.4
+:type: preprocessing
 */
 `define LONG_MACRO(
     a,

--- a/tests/generic/preproc/preproc_test_12.sv
+++ b/tests/generic/preproc/preproc_test_12.sv
@@ -3,6 +3,7 @@
 :description: Test
 :should_fail: 0
 :tags: 5.6.4
+:type: preprocessing
 */
 `define LONG_MACRO(
     a, b=2, c=42) \

--- a/tests/generic/preproc/preproc_test_13.sv
+++ b/tests/generic/preproc/preproc_test_13.sv
@@ -3,6 +3,7 @@
 :description: Test
 :should_fail: 0
 :tags: 5.6.4
+:type: preprocessing
 */
 `define LONG_MACRO(
     a, b="(3,2)", c=(3,2)) \

--- a/tests/generic/preproc/preproc_test_2.sv
+++ b/tests/generic/preproc/preproc_test_2.sv
@@ -3,6 +3,7 @@
 :description: Test
 :should_fail: 0
 :tags: 5.6.4
+:type: preprocessing
 */
 `include "preproc_test_2.svh"
 `ifndef SUCCESS

--- a/tests/generic/preproc/preproc_test_4.sv
+++ b/tests/generic/preproc/preproc_test_4.sv
@@ -3,6 +3,7 @@
 :description: Test
 :should_fail: 0
 :tags: 5.6.4
+:type: preprocessing
 */
 `ifdef INSANITY
 `define INSANITY // comment

--- a/tests/generic/preproc/preproc_test_5.sv
+++ b/tests/generic/preproc/preproc_test_5.sv
@@ -3,5 +3,6 @@
 :description: Test
 :should_fail: 0
 :tags: 5.6.4
+:type: preprocessing
 */
 `define INCEPTION(a, b, c)

--- a/tests/generic/preproc/preproc_test_6.sv
+++ b/tests/generic/preproc/preproc_test_6.sv
@@ -3,5 +3,6 @@
 :description: Test
 :should_fail: 0
 :tags: 5.6.4
+:type: preprocessing
 */
 `define INCEPTION(a, b, c) (a*b-c)

--- a/tests/generic/preproc/preproc_test_7.sv
+++ b/tests/generic/preproc/preproc_test_7.sv
@@ -3,6 +3,7 @@
 :description: Test
 :should_fail: 0
 :tags: 5.6.4
+:type: preprocessing
 */
 `define INCEPTION(a, b, c) \
   (a*b-c)

--- a/tests/generic/preproc/preproc_test_8.sv
+++ b/tests/generic/preproc/preproc_test_8.sv
@@ -3,6 +3,7 @@
 :description: Test
 :should_fail: 0
 :tags: 5.6.4
+:type: preprocessing
 */
 `define INCEPTION(xyz) \
   `define DEEPER (xyz)

--- a/tests/generic/preproc/preproc_test_9.sv
+++ b/tests/generic/preproc/preproc_test_9.sv
@@ -3,6 +3,7 @@
 :description: Test
 :should_fail: 0
 :tags: 5.6.4
+:type: preprocessing
 */
 `define LONG_MACRO(
     a, b, c)

--- a/tools/BaseRunner.py
+++ b/tools/BaseRunner.py
@@ -31,17 +31,37 @@ class BaseRunner:
     Runners must be located in tools/runners subdirectory
     to be detected and launched by the Makefile.
     """
-    def __init__(self, name, executable=None):
+    def __init__(
+            self,
+            name,
+            executable=None,
+            supported_features={'preprocessing', 'parsing', 'simulation'}):
         """Base runner class constructor
         Arguments:
         name -- runner name.
         executable -- name of an executable used by the particular runner
         can be omitted if default can_run method isn't used.
+        supported_features -- list of supported test types
         """
         self.name = name
         self.executable = executable
+        self.supported_features = supported_features
 
         self.url = "https://github.com/symbiflow/sv-tests"
+
+    def get_mode(self, test_features):
+        """Determine correct run mode or return None when incompatible
+        """
+        basic_features = ['parsing', 'preprocessing']
+        for feature in basic_features:
+            if feature in test_features and feature not in self.supported_features:
+                return None
+
+        features = ['simulation', *basic_features]
+
+        for feature in features:
+            if feature in test_features and feature in self.supported_features:
+                return feature
 
     def run(self, tmp_dir, params):
         """Run the provided test case

--- a/tools/BaseRunner.py
+++ b/tools/BaseRunner.py
@@ -53,9 +53,12 @@ class BaseRunner:
         """Determine correct run mode or return None when incompatible
         """
         basic_features = ['parsing', 'preprocessing']
+        previous_required = False
         for feature in basic_features:
-            if feature in test_features and feature not in self.supported_features:
+            if feature in test_features and feature not in self.supported_features and previous_required:
                 return None
+            if feature in test_features and feature in self.supported_features:
+                previous_required = True
 
         features = ['simulation', *basic_features]
 

--- a/tools/logparser.py
+++ b/tools/logparser.py
@@ -1,0 +1,13 @@
+import re
+
+
+def parseLog(log):
+    res = True
+    for line in log.split('\n'):
+        pat = re.search(r':([a-z]+):(.*)', line.strip())
+        if pat:
+            if pat.group(1) == 'assert':
+                expr = pat.group(2)
+                if not eval(expr):
+                    res = False
+    return res

--- a/tools/runner
+++ b/tools/runner
@@ -8,6 +8,7 @@ import logging
 import argparse
 import tempfile
 from importlib import import_module
+from logparser import parseLog
 
 parser = argparse.ArgumentParser()
 
@@ -75,7 +76,7 @@ test = os.path.abspath(os.path.join(dirs['tests'], args.test))
 
 req_test_params = [
     "name", "tags", "description", "should_fail", "files", "incdirs",
-    "top_module", "timeout"
+    "top_module", "timeout", "type"
 ]
 
 test_params = {}
@@ -110,6 +111,7 @@ try:
             test_params.setdefault('incdirs', os.path.dirname(test))
             test_params.setdefault('top_module', '')
             test_params.setdefault('timeout', "10")
+            test_params.setdefault('type', 'parsing')
 
             if len(set(req_test_params) - set(test_params.keys())) != 0:
                 missing = list(set(req_test_params) - set(test_params.keys()))
@@ -126,6 +128,12 @@ test_params['incdirs'] = list(
     map(
         lambda x: os.path.abspath(os.path.join(dirs['tests'], x)),
         test_params['incdirs'].split()))
+
+test_params['mode'] = runner_obj.get_mode(test_params['type'].split())
+
+if test_params['mode'] is None:
+    logger.info("Skipping {}/{}".format(args.runner, args.test))
+    sys.exit(0)
 
 try:
     tmp_dir = tempfile.mkdtemp()
@@ -152,6 +160,9 @@ try:
     tool_failed = test_params["rc"] != 0
 
     test_passed = rc < 126 and tool_should_fail == tool_failed
+
+    if test_passed and test_params['mode'] == 'simulation':
+        test_passed = parseLog(output)
 
     if test_passed:
         logger.info("PASS: {}/{}".format(args.runner, args.test))

--- a/tools/runners/Odin.py
+++ b/tools/runners/Odin.py
@@ -3,7 +3,7 @@ from BaseRunner import BaseRunner
 
 class Odin(BaseRunner):
     def __init__(self):
-        super().__init__("odin", "odin_II")
+        super().__init__("odin", "odin_II", {"preprocessing", "parsing"})
 
         self.url = "https://verilogtorouting.org/"
 

--- a/tools/runners/Slang.py
+++ b/tools/runners/Slang.py
@@ -3,7 +3,7 @@ from BaseRunner import BaseRunner
 
 class Slang(BaseRunner):
     def __init__(self):
-        super().__init__("slang", "slang-driver")
+        super().__init__("slang", "slang-driver", {"preprocessing", "parsing"})
 
         self.url = "https://github.com/MikePopoloski/slang"
 

--- a/tools/runners/Sv2v_zachjs.py
+++ b/tools/runners/Sv2v_zachjs.py
@@ -3,7 +3,8 @@ from BaseRunner import BaseRunner
 
 class Sv2v_zachjs(BaseRunner):
     def __init__(self):
-        super().__init__("zachjs-sv2v", "zachjs-sv2v")
+        super().__init__(
+            "zachjs-sv2v", "zachjs-sv2v", {"preprocessing", "parsing"})
 
         self.url = "https://github.com/zachjs/sv2v"
 

--- a/tools/runners/sv_parser.py
+++ b/tools/runners/sv_parser.py
@@ -3,7 +3,7 @@ from BaseRunner import BaseRunner
 
 class sv_parser(BaseRunner):
     def __init__(self):
-        super().__init__("sv-parser", "parse_sv")
+        super().__init__("sv-parser", "parse_sv", {"preprocessing", "parsing"})
 
         self.url = "https://github.com/dalance/sv-parser"
 

--- a/tools/runners/tree_sitter_verilog.py
+++ b/tools/runners/tree_sitter_verilog.py
@@ -12,7 +12,7 @@ class tree_sitter_verilog(BaseRunner):
     conpath = ['lib', libname]
 
     def __init__(self):
-        super().__init__("tree-sitter-verilog")
+        super().__init__("tree-sitter-verilog", None, {"parsing"})
 
         self.url = "https://github.com/tree-sitter/tree-sitter-verilog"
 

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -4,6 +4,7 @@ from pygments.formatters import HtmlFormatter
 from pygments import lexers, highlight
 import multiprocessing
 from glob import glob
+from logparser import parseLog
 import argparse
 import logging
 import jinja2
@@ -245,7 +246,7 @@ def collect_logs(runner_name):
         test_tags = [
             "name", "tags", "should_fail", "rc", "description", "files",
             "incdirs", "top_module", "runner", "runner_url", "time_elapsed",
-            "timeout"
+            "timeout", "type", "mode"
         ]
         with open(t, "r") as f:
             try:
@@ -285,6 +286,9 @@ def collect_logs(runner_name):
             tool_rc = int(tests[t_id]["rc"])
             tool_failed = (tool_rc != 0)
             if tool_rc >= 126 or tool_should_fail != tool_failed:
+                tests[t_id]["status"] = "test-failed"
+            elif tests[t_id]["mode"] == 'simulation' and not parseLog(
+                    tests[t_id]["log"]):
                 tests[t_id]["status"] = "test-failed"
             else:
                 tests[t_id]["status"] = "test-passed"


### PR DESCRIPTION
This PR adds support for specifying test types in the metadata - `simulation` and `parsing`, which can influence how runner handles that test case
At the moment Icarus and Verilator support simulation tests
Simulation results are verified with help of assert expressions placed in logs using `$display` statements ie. to make the tool check if `val == 5` place `$display(":assert:(%d == 5)", val);` somewhere in the `.sv` file
Additionally this adds two tags `simulation` and `parsing` to view tests only of that type

When no type is specified or is set as simulation and current runner doesn't support it then test is marked as a parsing test