### PR TITLE
Add some files of hdlconv to blacklist

### DIFF
--- a/conf/generators/meta-path/hdlconvertor.json
+++ b/conf/generators/meta-path/hdlconvertor.json
@@ -6,5 +6,6 @@
 		["tests", "hdlconvertor", "tests", "sv_test", "*"],
 		["tests", "hdlconvertor", "tests", "verilog"]
 	],
-	"matches": ["*.sv", "*.v"]
+	"matches": ["*.sv", "*.v"],
+	"blacklist": ["p12.sv", "p940.sv"]
 }


### PR DESCRIPTION
This PR add some files of hdlconv to blacklist.

* p12.sv: `* module mux2to1` is invalid.
* p940.sv: `import "DPI-C" \begin` is invalid because `\begin` is not c_identifier.

```
dpi_import_export ::= import dpi_spec_string [ dpi_function_import_property ] [ c_identifier = ] dpi_function_proto ;
c_identifier ::= [ a-zA-Z_ ] { [ a-zA-Z0-9_ ] }
```