### PR TITLE
Make sure the whole report table is always visible

### DIFF
--- a/conf/report/report-template.html
+++ b/conf/report/report-template.html
@@ -141,7 +141,7 @@
   </body>
 
   <br> <br>
-  <footer>
+  <footer id="footer">
     Generated using <a href="https://github.com/SymbiFlow/sv-tests">sv-tests</a>,
     revision: <a href="https://github.com/SymbiFlow/sv-tests/commit/{{revision}}">{{revision}}</a>.
   </footer>

--- a/conf/report/report.js
+++ b/conf/report/report.js
@@ -134,6 +134,13 @@ function toggleLog(tool, tag, test) {
 
   cell = document.getElementById(cell_id);
   cell.classList.toggle("test-cell-selected");
+
+  footer = document.getElementById("footer");
+  logs = document.getElementById("logfile-outer");
+
+  scroll = document.documentElement.scrollTop;
+  footer.style.marginBottom = logs.offsetHeight + "px";
+  document.documentElement.scrollTop = sroll;
 }
 
 function hideLog(div_id) {


### PR DESCRIPTION
Adjust the margin at the bottom of the page each time a log is
displayed.

This helps the situation when you are at the very bottom of the table and the log popup covers the table in a way that you are unable to switch for example to another tool.

With this change the whole table can be visible at all times.

Note that I also experimented with separating the page into two panels, but I thing the usability drops with that setup. It seems much more user friendly when the logs are in a modal window which can easily be closed (if you are interested in the overview report).