### PR TITLE
Added memory and time measurement to runner classes

### DIFF
--- a/tools/BaseRunner.py
+++ b/tools/BaseRunner.py
@@ -40,7 +40,8 @@ class BaseRunner:
         params -- dictionary with all metadata from the test file.
                   All keys are used without colons, ie. :tags: becomes tags.
 
-        Returns a tuple containing command execution log and return code.
+        Returns a tuple containing command execution log, return code,
+        user time, system time and ram usage
         """
         self.prepare_run_cb(tmp_dir, params)
 
@@ -53,7 +54,10 @@ class BaseRunner:
 
         log, _ = proc.communicate()
 
-        return (log.decode('utf-8'), proc.returncode)
+        usage = resource.getrusage(resource.RUSAGE_CHILDREN)
+        profiling_data = (usage.ru_utime, usage.ru_stime, usage.ru_maxrss)
+
+        return (log.decode('utf-8'), proc.returncode) + profiling_data
 
     def can_run(self):
         """Check if runner can be used

--- a/tools/runner
+++ b/tools/runner
@@ -3,7 +3,6 @@
 import os
 import re
 import sys
-import time
 import shutil
 import logging
 import argparse
@@ -127,14 +126,16 @@ except (PermissionError, FileExistsError) as e:
 try:
     logger.info("Running {}/{}".format(args.runner, args.test))
 
-    started = time.time()
-    output, rc = runner_obj.run(tmp_dir, test_params)
-    finished = time.time()
+    output, rc, user_time, system_time, ram_usage = runner_obj.run(
+        tmp_dir, test_params)
 
     test_params['rc'] = rc
     test_params['runner'] = runner_obj.name
     test_params['runner_url'] = runner_obj.url
-    test_params['time_elapsed'] = str(finished - started)
+    test_params['time_elapsed'] = str(user_time + system_time)
+    test_params['user_time'] = user_time
+    test_params['system_time'] = system_time
+    test_params['ram_usage'] = ram_usage
 
     tool_should_fail = test_params["should_fail"] == "1"
     tool_failed = test_params["rc"] != 0

--- a/tools/runners/tree_sitter_verilog.py
+++ b/tools/runners/tree_sitter_verilog.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import resource
 
 from tree_sitter import Language, Parser
 from BaseRunner import BaseRunner
@@ -62,8 +63,10 @@ class tree_sitter_verilog(BaseRunner):
             except Exception as e:
                 self.log_error(src, '', '', 'unknown error: ' + str(e))
                 self.ret = 1
+        usage = resource.getrusage(resource.RUSAGE_SELF)
+        profiling_data = (usage.ru_utime, usage.ru_stime, usage.ru_maxrss)
 
-        return (self.log, self.ret)
+        return (self.log, self.ret) + profiling_data
 
     def can_run(self):
         try:


### PR DESCRIPTION
Default implementation of `run` in `BaseRunner` spawns subprocess and measures the time for that child process. Script `tree_sitter_verilog.py` is the only one that overrides run and works entirely inside python, that's why the profiling is done for the process itself.