### PR TITLE
Modified report generating script and html templates

### DIFF
--- a/conf/report/log-template.html
+++ b/conf/report/log-template.html
@@ -17,6 +17,7 @@ type: {{type|e}}
 mode: {{mode|e}}
 files: {{file_urls}}
 time_elapsed: {{'%0.3f'| format(time_elapsed|float)}}s
+ram usage: {{'%d'| format(ram_usage|int)}} KB
 </pre>
 <pre class="log">
 {{log_urls}}

--- a/conf/report/report-template.html
+++ b/conf/report/report-template.html
@@ -134,21 +134,21 @@
             {{'%0.2f'| format(report[tool]["time_elapsed"]|float)}}s </th>
           {% endfor %}
         </tr>
-	<tr>
+	<tr class="report_summary_row">
           <th class="report_table_info" colspan="2"> User time elapsed: </th>
           {% for tool in report %}
           <th class="report_table_result" title="{{ tool.lower() }}" >
             {{'%0.2f'| format(report[tool]["user_time"]|float)}}s </th>
           {% endfor %}
         </tr>
-	<tr>
+	<tr class="report_summary_row">
           <th class="report_table_info" colspan="2"> System time elapsed: </th>
           {% for tool in report %}
           <th class="report_table_result" title="{{ tool.lower() }}" >
             {{'%0.2f'| format(report[tool]["system_time"]|float)}}s </th>
           {% endfor %}
         </tr>
-	<tr>
+	<tr class="report_summary_row">
           <th class="report_table_info" colspan="2"> Maximum ram usage: </th>
           {% for tool in report %}
           <th class="report_table_result" title="{{ tool.lower() }}" >

--- a/conf/report/report-template.html
+++ b/conf/report/report-template.html
@@ -134,6 +134,27 @@
             {{'%0.2f'| format(report[tool]["time_elapsed"]|float)}}s </th>
           {% endfor %}
         </tr>
+	<tr>
+          <th class="report_table_info" colspan="2"> User time elapsed: </th>
+          {% for tool in report %}
+          <th class="report_table_result" title="{{ tool.lower() }}" >
+            {{'%0.2f'| format(report[tool]["user_time"]|float)}}s </th>
+          {% endfor %}
+        </tr>
+	<tr>
+          <th class="report_table_info" colspan="2"> System time elapsed: </th>
+          {% for tool in report %}
+          <th class="report_table_result" title="{{ tool.lower() }}" >
+            {{'%0.2f'| format(report[tool]["system_time"]|float)}}s </th>
+          {% endfor %}
+        </tr>
+	<tr>
+          <th class="report_table_info" colspan="2"> Maximum ram usage: </th>
+          {% for tool in report %}
+          <th class="report_table_result" title="{{ tool.lower() }}" >
+            {{'%0.2f'| format(report[tool]["ram_usage"]|float)}} MB </th>
+          {% endfor %}
+        </tr>
       </tfoot>
     </table>
     <br>

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -235,6 +235,9 @@ def collect_logs(runner_name):
     runner_data["tests"] = {}
     tests = runner_data["tests"]
     runner_data["time_elapsed"] = 0
+    runner_data["user_time"] = 0
+    runner_data["system_time"] = 0
+    runner_data["ram_usage"] = 0
 
     for t in glob(os.path.join(args.logs, runner_name, "**/*.log"),
                   recursive=True):
@@ -246,7 +249,7 @@ def collect_logs(runner_name):
         test_tags = [
             "name", "tags", "should_fail", "rc", "description", "files",
             "incdirs", "top_module", "runner", "runner_url", "time_elapsed",
-            "timeout", "type", "mode"
+            "type", "mode", "timeout", "user_time", "system_time", "ram_usage"
         ]
         with open(t, "r") as f:
             try:
@@ -300,6 +303,11 @@ def collect_logs(runner_name):
             tests[t_id]["first_file"] = logToHTML(t, t_html, tests[t_id])
 
             runner_data["time_elapsed"] += float(tests[t_id]["time_elapsed"])
+            runner_data["user_time"] += float(tests[t_id]["user_time"])
+            runner_data["system_time"] += float(tests[t_id]["system_time"])
+            current_ram_usage = float(tests[t_id]["ram_usage"]) / 1000
+            if runner_data["ram_usage"] < current_ram_usage:
+                runner_data["ram_usage"] = current_ram_usage
 
         # check if test was skipped
         if t_id not in tests:


### PR DESCRIPTION
The data is now displayed in the html report:
- each test has it's individual memory usage listed in the pop-out window
- sum of user and kernel time and maximum ram usage is displayed at the bottom of the page, under respective simulator