### PR TITLE
Add simulator type to testcases for semantic error

### DIFF
--- a/conf/generators/templates/encapsulation.json
+++ b/conf/generators/templates/encapsulation.json
@@ -7,6 +7,7 @@
 		":description: encapsulation test",
 		":should_fail: {1}",
 		":tags: 8.18",
+		":type: {3}",
 		"*/",
 		"module top();",
 		"class a_cls;",
@@ -31,13 +32,13 @@
 		"endmodule"
 	],
 	"values": [
-		["inherited_local_from_outside", "1", "b", "a_loc"],
-		["local_from_outside", "1", "b", "b_loc"],
-		["inherited_prot_from_outside", "1", "b", "a_prot"],
-		["prot_from_outside", "1", "b", "b_prot"],
-		["inherited_local_from_inside", "1", "a_loc", "b"],
-		["local_from_inside", "0", "b_loc", "b"],
-		["inherited_prot_from_inside", "0", "a_prot", "b"],
-		["prot_from_inside", "0", "b_prot", "b"]
+		["inherited_local_from_outside", "1", "b", "a_loc", "simulation"],
+		["local_from_outside", "1", "b", "b_loc", "simulation"],
+		["inherited_prot_from_outside", "1", "b", "a_prot", "simulation"],
+		["prot_from_outside", "1", "b", "b_prot", "simulation"],
+		["inherited_local_from_inside", "1", "a_loc", "b", "simulation"],
+		["local_from_inside", "0", "b_loc", "b", "simulation parsing"],
+		["inherited_prot_from_inside", "0", "a_prot", "b", "simulation parsing"],
+		["prot_from_inside", "0", "b_prot", "b", "simulation parsing"]
 	]
 }

--- a/tests/chapter-11/11.4.14.3--unpack_stream_inv.sv
+++ b/tests/chapter-11/11.4.14.3--unpack_stream_inv.sv
@@ -3,6 +3,7 @@
 :description: invalid stream unpack test
 :should_fail: 1
 :tags: 11.4.14.3
+:type: simulation
 */
 module top();
 

--- a/tests/chapter-11/11.9--tagged_union_member_access_inv.sv
+++ b/tests/chapter-11/11.9--tagged_union_member_access_inv.sv
@@ -3,6 +3,7 @@
 :description: invalid tagged union member access test
 :should_fail: 1
 :tags: 11.9
+:type: simulation
 */
 module top();
 

--- a/tests/chapter-5/5.10-structure-arrays-illegal.sv
+++ b/tests/chapter-5/5.10-structure-arrays-illegal.sv
@@ -3,6 +3,7 @@
 :description: Structure array assignment tests
 :should_fail: 1
 :tags: 5.10
+:type: simulation
 */
 module top();
   typedef struct {

--- a/tests/chapter-6/6.12--real_bit_select.sv
+++ b/tests/chapter-6/6.12--real_bit_select.sv
@@ -3,6 +3,7 @@
 :description: real indexing tests
 :should_fail: 1
 :tags: 6.12
+:type: simulation
 */
 module top();
 	real a = 0.5;

--- a/tests/chapter-6/6.12--real_bit_select_idx.sv
+++ b/tests/chapter-6/6.12--real_bit_select_idx.sv
@@ -3,6 +3,7 @@
 :description: real bit select tests
 :should_fail: 1
 :tags: 6.12
+:type: simulation
 */
 module top();
 	real a = 0.5;

--- a/tests/chapter-6/6.12--real_edge.sv
+++ b/tests/chapter-6/6.12--real_edge.sv
@@ -3,6 +3,7 @@
 :description: real edge event tests
 :should_fail: 1
 :tags: 6.12
+:type: simulation
 */
 module top();
 	real a = 0.5;

--- a/tests/chapter-6/6.19--enum_xx_inv.sv
+++ b/tests/chapter-6/6.19--enum_xx_inv.sv
@@ -3,6 +3,7 @@
 :description: invalid enum with x tests
 :should_fail: 1
 :tags: 6.19
+:type: simulation
 */
 module top();
 	enum bit [1:0] {a=0, b=2'bxx, c=1} val;

--- a/tests/chapter-6/6.19--enum_xx_inv_order.sv
+++ b/tests/chapter-6/6.19--enum_xx_inv_order.sv
@@ -3,6 +3,7 @@
 :description: unassigned name following enum with x tests
 :should_fail: 1
 :tags: 6.19
+:type: simulation
 */
 module top();
 	enum integer {a=0, b={32{1'bx}}, c} val;

--- a/tests/chapter-6/6.19.3--enum_type_checking_inv.sv
+++ b/tests/chapter-6/6.19.3--enum_type_checking_inv.sv
@@ -3,6 +3,7 @@
 :description: invalid enum assignment tests
 :should_fail: 1
 :tags: 6.19.3
+:type: simulation
 */
 module top();
 	typedef enum {a, b, c, d} e;

--- a/tests/chapter-6/6.19.4--enum_numerical_expr_no_cast.sv
+++ b/tests/chapter-6/6.19.4--enum_numerical_expr_no_cast.sv
@@ -3,6 +3,7 @@
 :description: enum numerical expression without casting
 :should_fail: 1
 :tags: 6.19.4
+:type: simulation
 */
 module top();
 	typedef enum {a, b, c, d} e;

--- a/tests/chapter-6/6.20.5--specparam_inv.sv
+++ b/tests/chapter-6/6.20.5--specparam_inv.sv
@@ -3,6 +3,7 @@
 :description: specparam assignment to param should be invalid
 :should_fail: 1
 :tags: 6.20.5
+:type: simulation
 */
 module top();
 	specparam delay = 50;

--- a/tests/chapter-6/6.5--variable_mixed_assignments.sv
+++ b/tests/chapter-6/6.5--variable_mixed_assignments.sv
@@ -3,6 +3,7 @@
 :description: Variable mixed assignments tests
 :should_fail: 1
 :tags: 6.5
+:type: simulation
 */
 module top();
 	wire clk = 0;

--- a/tests/chapter-6/6.5--variable_multiple_assignments.sv
+++ b/tests/chapter-6/6.5--variable_multiple_assignments.sv
@@ -3,6 +3,7 @@
 :description: Variable multiple assignments tests
 :should_fail: 1
 :tags: 6.5
+:type: simulation
 */
 module top();
 	int v;

--- a/tests/chapter-6/6.5--variable_redeclare.sv
+++ b/tests/chapter-6/6.5--variable_redeclare.sv
@@ -3,6 +3,7 @@
 :description: Variable redeclaration tests
 :should_fail: 1
 :tags: 6.5
+:type: simulation
 */
 module top();
 	reg v;

--- a/tests/chapter-7/arrays/packed/variable-slice-zero.sv
+++ b/tests/chapter-7/arrays/packed/variable-slice-zero.sv
@@ -3,7 +3,7 @@
 :description: Test packed arrays operations support (Variable slice)
 :should_fail: 1
 :tags: 7.4.3
-:type: simulation parsing
+:type: simulation
 */
 module top ();
 

--- a/tests/chapter-7/structures/packed/default-value.sv
+++ b/tests/chapter-7/structures/packed/default-value.sv
@@ -3,6 +3,7 @@
 :description: Test packed structures default value support
 :should_fail: 1
 :tags: 7.2.2
+:type: simulation
 */
 module top ();
 

--- a/tests/chapter-8/8.21--abstract_class_inst.sv
+++ b/tests/chapter-8/8.21--abstract_class_inst.sv
@@ -3,6 +3,7 @@
 :description: instantiating abstract class
 :should_fail: 1
 :tags: 8.21
+:type: simulation
 */
 module class_tb ();
 	virtual class base_cls;

--- a/tests/chapter-8/8.25.1--parametrized_class_invalid_scope_resolution.sv
+++ b/tests/chapter-8/8.25.1--parametrized_class_invalid_scope_resolution.sv
@@ -3,6 +3,7 @@
 :description: parametrized class invalid scope resolution
 :should_fail: 1
 :tags: 8.25.1
+:type: simulation
 */
 module class_tb ();
 

--- a/tests/chapter-8/8.26.3--type_access_implements_invalid.sv
+++ b/tests/chapter-8/8.26.3--type_access_implements_invalid.sv
@@ -3,6 +3,7 @@
 :description: access types from implemented class
 :should_fail: 1
 :tags: 8.26.3
+:type: simulation
 */
 module class_tb ();
 	interface class ihello;

--- a/tests/chapter-8/8.26.4--illegal_forward_def_implements.sv
+++ b/tests/chapter-8/8.26.4--illegal_forward_def_implements.sv
@@ -3,6 +3,7 @@
 :description: implementing forward typedef for an interface class should fail
 :should_fail: 1
 :tags: 8.26.4
+:type: simulation
 */
 module class_tb ();
 	typedef interface class ihello;

--- a/tests/chapter-8/8.26.4--illegal_implements_parameter.sv
+++ b/tests/chapter-8/8.26.4--illegal_implements_parameter.sv
@@ -3,6 +3,7 @@
 :description: implementing parameter that resolves to an interface class is not allowed
 :should_fail: 1
 :tags: 8.26.4
+:type: simulation
 */
 module class_tb ();
 	interface class ihello;

--- a/tests/chapter-8/8.26.5--invalid_interface_instantiation.sv
+++ b/tests/chapter-8/8.26.5--invalid_interface_instantiation.sv
@@ -3,6 +3,7 @@
 :description: instantiating an interface class
 :should_fail: 1
 :tags: 8.26.5
+:type: simulation
 */
 module class_tb ();
 	interface class ihello;

--- a/tests/chapter-8/8.26.6.1--name_conflict_unresolved.sv
+++ b/tests/chapter-8/8.26.6.1--name_conflict_unresolved.sv
@@ -3,6 +3,7 @@
 :description: unresolved interface class method name conflict
 :should_fail: 1
 :tags: 8.26.6.1
+:type: simulation
 */
 module class_tb ();
 	interface class ihello;

--- a/tests/chapter-8/8.26.6.2--parameter_type_conflict_unresolved.sv
+++ b/tests/chapter-8/8.26.6.2--parameter_type_conflict_unresolved.sv
@@ -3,6 +3,7 @@
 :description: superclass type declaration conflicts must be resolved in subclass
 :should_fail: 1
 :tags: 8.26.6.2
+:type: simulation
 */
 module class_tb ();
 	interface class ic1#(type T = logic);

--- a/tests/chapter-8/8.26.6.3--diamond_relationship_parametrized.sv
+++ b/tests/chapter-8/8.26.6.3--diamond_relationship_parametrized.sv
@@ -3,6 +3,7 @@
 :description: different specializations of an interface class are treated as unique interface class types
 :should_fail: 1
 :tags: 8.26.6.3
+:type: simulation
 */
 module class_tb ();
 	interface class ibase#(type T = logic);

--- a/tests/chapter-9/9.3.3--fork_return.sv
+++ b/tests/chapter-9/9.3.3--fork_return.sv
@@ -3,6 +3,7 @@
 :description: illegal return from fork
 :should_fail: 1
 :tags: 9.3.3
+:type: simulation
 */
 module block_tb ();
 	task fork_test;


### PR DESCRIPTION
Some testcases having `:should_fail: 1` can't be passed by parser because it is semantic error.
