### PR TITLE
compatibility with BSD sed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ endif
 info:
 	@echo -e "Found the following runners:$(subst $(space),"\\n \* ", $(RUNNERS))\n"
 
-PY_FILES := $(shell file generators/* tools/* | sed -ne 's/:.*python.*//pI')
+PY_FILES := $(shell file generators/* tools/* | sed -ne 's/:.*[Pp]ython.*//p')
 PY_FILES += $(wildcard tools/*.py)
 PY_FILES += $(wildcard tools/runners/*.py)
 


### PR DESCRIPTION
The `sed` distributed on macOS doesn't support the `I` flag. I believe this alternative should serve the intended purpose.