### PR TITLE
Reduce visual noise in the footer

### DIFF
--- a/conf/report/report-template.html
+++ b/conf/report/report-template.html
@@ -115,44 +115,44 @@
       {% endfor %}
       <tfoot>
         <tr class="report_summary_row">
-          <th class="report_summary_header" colspan="2"> Total tests passed: </th>
+          <th class="report_summary_header" colspan="2"> Total tests passed </th>
 
           {% for tool, tooldata in report|dictsort %}
           <th class="report_table_result" title="{{ tool.lower() }}" > {{ report[tool]["total"]["tests"] }}/{{ report[tool]["tests"].keys()|length }}</th>
           {% endfor %}
         </tr>
         <tr class="report_summary_row">
-          <th class="report_summary_header" colspan="2"> Total tags passed: </th>
+          <th class="report_summary_header" colspan="2"> Total tags passed </th>
           {% for tool, tooldata in report|dictsort %}
           <th class="report_table_result" title="{{ tool.lower() }}" > {{ report[tool]["total"]["tags"]}}/{{ database.keys()|length}}</th>
           {% endfor %}
         </tr>
         <tr class="report_summary_row">
-          <th class="report_summary_header" colspan="2"> Total time elapsed: </th>
+          <th class="report_summary_header" colspan="2"> Total time elapsed </th>
           {% for tool, tooldata in report|dictsort %}
           <th class="report_table_result" title="{{ tool.lower() }}" >
-            {{'%0.2f'| format(report[tool]["time_elapsed"]|float)}}s </th>
+            {{'%0.0f'| format(report[tool]["time_elapsed"])}}s </th>
           {% endfor %}
         </tr>
-	<tr class="report_summary_row">
-          <th class="report_table_info" colspan="2"> User time elapsed: </th>
+        <tr class="report_summary_row">
+          <th class="report_table_info" colspan="2"> User time elapsed </th>
           {% for tool, tooldata in report|dictsort %}
           <th class="report_table_result" title="{{ tool.lower() }}" >
-            {{'%0.2f'| format(report[tool]["user_time"]|float)}}s </th>
+            {{'%0.0f'| format(report[tool]["user_time"])}}s </th>
           {% endfor %}
         </tr>
-	<tr class="report_summary_row">
-          <th class="report_table_info" colspan="2"> System time elapsed: </th>
+        <tr class="report_summary_row">
+          <th class="report_table_info" colspan="2"> System time elapsed </th>
           {% for tool, tooldata in report|dictsort %}
           <th class="report_table_result" title="{{ tool.lower() }}" >
-            {{'%0.2f'| format(report[tool]["system_time"]|float)}}s </th>
+            {{'%0.0f'| format(report[tool]["system_time"])}}s </th>
           {% endfor %}
         </tr>
-	<tr class="report_summary_row">
-          <th class="report_table_info" colspan="2"> Maximum ram usage: </th>
+        <tr class="report_summary_row">
+          <th class="report_table_info" colspan="2"> Maximum ram usage </th>
           {% for tool, tooldata in report|dictsort %}
           <th class="report_table_result" title="{{ tool.lower() }}" >
-            {{'%0.2f'| format(report[tool]["ram_usage"]|float)}} MB </th>
+            {{'%0.0f'| format(report[tool]["ram_usage"])}} MB </th>
           {% endfor %}
         </tr>
       </tfoot>

--- a/conf/report/report.css
+++ b/conf/report/report.css
@@ -26,6 +26,11 @@ table.dataTable tfoot th {
   max-width: 30em;
 }
 
+tfoot .report_table_result {
+  font-weight: normal !important;
+  text-align: right;
+}
+
 .report_summary_row {
   background-color: lightgray;
 }


### PR DESCRIPTION
These changes are obviously subjective. I'm eager to receive any feedback.

Before:
<img width="814" alt="image" src="https://user-images.githubusercontent.com/2541204/67996587-5534ef00-fc26-11e9-8836-c2eebdd161ab.png">


After: (local run with fewer tools set up)
<img width="871" alt="image" src="https://user-images.githubusercontent.com/2541204/67996563-39c9e400-fc26-11e9-8523-ee3aa11a10e6.png">
