### PR TITLE
Fix test type

### DIFF
--- a/tests/chapter-13/13.4.1--function-void-return.sv
+++ b/tests/chapter-13/13.4.1--function-void-return.sv
@@ -3,6 +3,7 @@
 :description: void function return value test
 :should_fail: 1
 :tags: 13.4.1
+:type: simulation
 */
 module top();
 

--- a/tests/chapter-13/13.4.4--fork-invalid.sv
+++ b/tests/chapter-13/13.4.4--fork-invalid.sv
@@ -3,7 +3,7 @@
 :description: function invalid fork test
 :should_fail: 1
 :tags: 13.4.4
-:type: simulation parsing
+:type: simulation
 */
 module top();
 


### PR DESCRIPTION
Some tests detecting semantic error should be `:type: simulation`.