### PR TITLE
Increase uvm timeout

### DIFF
--- a/generators/uvm
+++ b/generators/uvm
@@ -11,6 +11,7 @@ templ = """/*
 :incdirs: {1}
 :should_fail: 0
 :tags: uvm
+:timeout: 100
 */
 """
 


### PR DESCRIPTION
uvm seems to take a long time. In my environment, sv-parser took about 15s.
