### PR TITLE
Change type of timescale error case

### DIFF
--- a/tests/chapter-22/22.7--timescale-basic-3.sv
+++ b/tests/chapter-22/22.7--timescale-basic-3.sv
@@ -3,6 +3,6 @@
 :description: Test
 :should_fail: 1
 :tags: 22.7
-:type: preprocessing
+:type: simulation
 */
 `timescale 9 ns / 1 ps

--- a/tests/chapter-22/22.7--timescale-basic-4.sv
+++ b/tests/chapter-22/22.7--timescale-basic-4.sv
@@ -3,6 +3,6 @@
 :description: Test
 :should_fail: 1
 :tags: 22.7
-:type: preprocessing
+:type: simulation
 */
 `timescale 1 ns / 1000 ps


### PR DESCRIPTION
I think unit/precision check of timescale is semantic error.