### PR TITLE
Fix Verilator vmodel not found errors, bug438.

### DIFF
--- a/tools/logparser.py
+++ b/tools/logparser.py
@@ -8,6 +8,9 @@ def parseLog(log):
         if pat:
             if pat.group(1) == 'assert':
                 expr = pat.group(2)
-                if not eval(expr):
+                try:
+                    if not eval(expr):
+                        res = False
+                except Exception:
                     res = False
     return res

--- a/tools/runners/Verilator.py
+++ b/tools/runners/Verilator.py
@@ -45,7 +45,10 @@ class Verilator(BaseRunner):
             self.cmd.append('-I' + incdir)
 
         if mode == 'simulation':
-            self.cmd += ['--Mdir', build_dir, '--exe', '-o', build_exe]
+            self.cmd += [
+                '--Mdir', build_dir, '--prefix', 'Vtop', '--exe', '-o',
+                build_exe
+            ]
             self.cmd.append('vmain.cpp')
 
         self.cmd += params['files']


### PR DESCRIPTION
This fixes bug 438.
