### PR TITLE
Add some testcases of yosys to blacklist

### DIFF
--- a/conf/generators/meta-path/yosys-asicworld.json
+++ b/conf/generators/meta-path/yosys-asicworld.json
@@ -5,5 +5,6 @@
 	"paths": [
 		["tools", "yosys", "tests", "asicworld"]
 	],
-	"matches": ["*.v"]
+	"matches": ["*.v"],
+	"blacklist": ["code_verilog_tutorial_counter_tb.v", "code_hdl_models_arbiter_tb.v", "code_verilog_tutorial_first_counter_tb.v", "code_verilog_tutorial_fsm_full_tb.v"]
 }

--- a/conf/generators/meta-path/yosys-errors.json
+++ b/conf/generators/meta-path/yosys-errors.json
@@ -5,5 +5,6 @@
 	"paths": [
 		["tools", "yosys", "tests", "errors"]
 	],
-	"matches": ["*.v"]
+	"matches": ["*.v"],
+	"blacklist": ["syntax_err06.v", "syntax_err09.v", "syntax_err12.v", "syntax_err13.v"]
 }

--- a/conf/generators/meta-path/yosys-simple.json
+++ b/conf/generators/meta-path/yosys-simple.json
@@ -5,5 +5,6 @@
 	"paths": [
 		["tools", "yosys", "tests", "simple"]
 	],
-	"matches": ["*.v"]
+	"matches": ["*.v"],
+	"blacklist": ["hierdefparam.v", "memory.v"]
 }


### PR DESCRIPTION
This PR adds some testcases of yosys to blacklist.

* code_verilog_tutorial_counter_tb.v, code_hdl_models_arbiter_tb.v, code_verilog_tutorial_first_counter_tb.v, code_verilog_tutorial_fsm_full_tb.v

These include an undefined macro `outfile`.

* hierdefparam.v

`generate` block can't take `begin/end` directly.

* memory.v

`bit` is a reserved keyword.

* syntax_err06.v, syntax_err09.v, syntax_err13.v

These seem to be semantic error.

* syntax_err12.v

This may be semantic error.
`iface` can be user-defined type or interface syntactically.
If `iface` is used-defined type, the assignment is valid.