### PR TITLE
Fix error at basejump

### DIFF
--- a/conf/generators/meta-path/basejump.json
+++ b/conf/generators/meta-path/basejump.json
@@ -6,6 +6,15 @@
 		["cores", "basejump_stl", "*"]
 	],
 	"matches": ["*.v"],
+	"commons": [
+		"cores/basejump_stl/bsg_misc/bsg_defines.v",
+		"cores/basejump_stl/bsg_cache/bsg_cache_pkg.v",
+		"cores/basejump_stl/bsg_fpu/bsg_fpu_pkg.v"
+	],
+	"incdirs": [
+		"cores/basejump_stl/bsg_misc",
+		"cores/basejump_stl/bsg_noc"
+	],
 	"blacklist": [
 		"bsg_mesh_to_ring_stitch.v", "bsg_reduce_segmented.v",
 		"bsg_launch_sync_sync.v", "bsg_mem_multiport.v",
@@ -27,6 +36,9 @@
 		"bsg_cache_to_axi_tx.v", "bsg_mul_array.v", "bsg_mul_array.v",
 		"bsg_muxi2_gatestack.v", "bsg_async_credit_counter.v",
 		"bsg_mux_segmented.v", "bsg_dff_gatestack.v",
-		"bsg_cache_to_dram_ctrl_tx.v"
+		"bsg_cache_to_dram_ctrl_tx.v",
+		"test_bsg_clock_params.v", "bsg_nonsynth_mixin_motherboard.v",
+		"bsg_1_to_n_tagged_fifo_shared.v", "bsg_fifo_1r1w_large_banked.v",
+		"bsg_sbox_ctrl.v", "bsg_sort_4.v"
 	]
 }

--- a/generators/path_generator
+++ b/generators/path_generator
@@ -39,6 +39,8 @@ for cfg in glob.glob(os.path.join(conf_dir, 'generators', 'meta-path',
         paths = data['paths']
         matches = data['matches']
         blacklist = data.get('blacklist', [''])
+        commons = data.get('commons', [])
+        incdirs = data.get('incdirs', [])
 
     test_dir = os.path.join(tests_dir, 'generated', project)
 
@@ -57,8 +59,16 @@ for cfg in glob.glob(os.path.join(conf_dir, 'generators', 'meta-path',
                 fname = name + '_' + os.path.basename(os.path.splitext(f)[0])
                 test_file = os.path.join(test_dir, fname + '.sv')
 
-                incdirs = os.path.dirname(f)
+                incs = os.path.dirname(f)
+
+                for common in commons:
+                    f = os.path.abspath(
+                        os.path.join(third_party_dir, common)) + " " + f
+
+                for incdir in incdirs:
+                    incs = os.path.abspath(
+                        os.path.join(third_party_dir, incdir)) + " " + incs
 
                 with open(test_file, "w") as sv:
                     sv.write(
-                        templ.format(project, should_fail, f, fname, incdirs))
+                        templ.format(project, should_fail, f, fname, incs))


### PR DESCRIPTION
This is some fixes for basejump.

* Add `commons` to path_generator
basejump uses many defines at `cores/basejump_stl/bsg_misc/bsg_defines.v`.
The files in `commons` section are added to `:files:` by path_generator.

* Add `incdirs` to path_generator
basejump expects some include directory like `cores/basejump_stl/bsg_misc`.
The directories in `incdirs` section are added to `:incdirs:` by path_generator.

* Add some testcases to blacklist
  * test_bsg_clock_params.v
`initial` can't be at top-level.

  * bsg_nonsynth_mixin_motherboard.v
`` `BSG_NONSYNTH_MOTHERBOARD_MIXIN_module_name`` is not defined anywhere.

  * bsg_1_to_n_tagged_fifo_shared.v
`` `BSG_SAFE_CLOG2(buffering_p)`` in ``logic [num_out_p-1:0][`BSG_SAFE_CLOG2(buffering_p)] els;`` is not range.

  * bsg_fifo_1r1w_large_banked.v, bsg_sbox_ctrl.v, bsg_sort_4.v
There are module instantiations without instance identifier.