### PR TITLE
Fix some minor test issues

### DIFF
--- a/tests/chapter-7/arrays/associative/methods/traversal.sv
+++ b/tests/chapter-7/arrays/associative/methods/traversal.sv
@@ -7,14 +7,14 @@
 */
 module top ();
 
-string map[ int ];
+string map[ byte ];
 byte ix;
 int rc;
 
 initial begin
     map[ 1000 ] = "a";
     rc = map.first( ix );
-    $display(":assert: ( (%d == -1) and ('%b' == '11101000') )", rc, ix);
+    $display(":assert: ( ('%0d' == '1') and ('%b' == '11101000') )", rc, ix);
 end
 
 endmodule

--- a/tests/generic/number/number_test_63.sv
+++ b/tests/generic/number/number_test_63.sv
@@ -4,4 +4,4 @@
 :should_fail: 1
 :tags: 5.6.4 5.7.1 5.7.2
 */
-parameter int foo = 32'H_7f_FF_;
+parameter int foo = _23_;

--- a/tests/generic/typedef/typedef_test_22.sv
+++ b/tests/generic/typedef/typedef_test_22.sv
@@ -4,7 +4,8 @@
 :should_fail: 0
 :tags: 6.18
 */
-typedef enum uvec8_t {
+typedef enum uvec8_t;
+typedef enum {
   Global = 4'h2,
   Local = 4'h3
-} myenum_fwd;
+} uvec8_t;


### PR DESCRIPTION
number_test_63: Leading underscore in spec means before anything.
typedef_test_22: Fix to properly check for fwd decls.
associative/methods/traversal: Fix to avoid type mismatches.
