### PR TITLE
Fix number_test_63

### DIFF
--- a/tests/generic/number/number_test_63.sv
+++ b/tests/generic/number/number_test_63.sv
@@ -4,4 +4,4 @@
 :should_fail: 1
 :tags: 5.6.4 5.7.1 5.7.2
 */
-parameter int foo = _23_;
+timeunit _23_ns;


### PR DESCRIPTION
`_23_` is an invalid number but a valid identifier, so this test should be passed.
To check `_23_` as number, `time_literal` can be used because it can't take identifier.
