### PR TITLE
Misc test fixes

### DIFF
--- a/conf/runners/vmain.cpp
+++ b/conf/runners/vmain.cpp
@@ -6,6 +6,8 @@
 #include <Vtop.h>
 
 int main(int argc, char *argv[]) {
+	Verilated::commandArgs(argc, argv);
+
 	Vtop *top = new Vtop;
 
 	for (int i = 0; i < 1000 && !Verilated::gotFinish(); i++)

--- a/tests/chapter-11/11.4.13--set_member.sv
+++ b/tests/chapter-11/11.4.13--set_member.sv
@@ -8,8 +8,8 @@ module top();
 
 int a;
 int b = 12;
-int c = 5;
-int d = 7;
+localparam c = 5;
+localparam d = 7;
 
 initial begin
 	a = b inside {c, d};

--- a/tests/chapter-20/20.5--shortreal-bits-conv.sv
+++ b/tests/chapter-20/20.5--shortreal-bits-conv.sv
@@ -8,8 +8,11 @@
 
 module top();
 
+	shortreal s;
+
 initial begin
-	$display(":assert: (%f == 12.45)", $bitstoshortreal($shortrealtobits(12.45)));
+	s = $bitstoshortreal($shortrealtobits(12.45));
+	$display(":assert: (%0d == 1)", (s > 12.449 && s < 12.451));
 end
 
 endmodule

--- a/tests/chapter-22/22.10--celldefine-invalid.sv
+++ b/tests/chapter-22/22.10--celldefine-invalid.sv
@@ -1,8 +1,0 @@
-/*
-:name: 22.10--celldefine-invalid
-:description: Test
-:should_fail: 1
-:tags: 22.10
-:type: preprocessing
-*/
-`celldefine foo

--- a/tests/chapter-22/22.5.1--include-define-expansion.sv
+++ b/tests/chapter-22/22.5.1--include-define-expansion.sv
@@ -3,7 +3,7 @@
 :description: Test
 :should_fail: 0
 :tags: 22.5.1
-:type: preprocessing parsing
+:type: preprocessing
 */
 `define foo(the_file) `"the_file`"
 `include `foo(dummy_include.sv)

--- a/tests/chapter-22/dummy_include.sv
+++ b/tests/chapter-22/dummy_include.sv
@@ -1,6 +1,7 @@
 /*
 :name: dummy_include
 :description: Utility for testing `include directive
+:type: preprocessing
 :should_fail: 0
 :tags: 22.4
 */

--- a/tests/chapter-22/include_directory/defs.sv
+++ b/tests/chapter-22/include_directory/defs.sv
@@ -1,6 +1,7 @@
 /*
 :name: defs 
 :description: Utility for testing `include directive
+:type: preprocessing
 :should_fail: 0
 :tags: 22.4
 */

--- a/tests/chapter-24/24.3--program.sv
+++ b/tests/chapter-24/24.3--program.sv
@@ -5,16 +5,15 @@
 :tags: 24.3
 :type: simulation parsing
 */
-module top();
-
 program prog(input wire a, input wire b);
 	initial $display(":assert: (%d == %d)", a, b);
 endprogram
 
-wire w = 1;
+module top();
 
-initial begin
-	prog p(w, w);
-end
+   wire a = 1;
+   wire b = 1;
+
+   prog p(a, b);
 
 endmodule


### PR DESCRIPTION
This fixes the following test problems:
    11.4.13--set_member: test standard usage
    20.5--shortreal-bits-conv: Fix to account for rounding.
    21.6--test ($test$plusargs) requires argv
    22.5.1--include-define-expansion etc has no module; is preproc only.
    24.3--program.sv to be legal.
    Remove 22.10--celldefine-invalid. IEEE does not specifiy celldefine is alone on line or not, hence legal if foo is passed through and passes.
