### PR TITLE
Make verible build less noisy.

### DIFF
--- a/tools/runners.mk
+++ b/tools/runners.mk
@@ -81,7 +81,7 @@ $(INSTALL_DIR)/bin/moore:
 verible: $(INSTALL_DIR)/bin/verilog_syntax
 
 $(INSTALL_DIR)/bin/verilog_syntax:
-	cd $(RDIR)/verible/ && bazel build --cxxopt='-std=c++17' //...
+	cd $(RDIR)/verible/ && bazel build --noshow_progress --cxxopt='-std=c++17' //...
 	install -D $(RDIR)/verible/bazel-bin/verilog/tools/syntax/verilog_syntax $@
 
 # setup the dependencies


### PR DESCRIPTION
Building all runners in parallel is pretty noisy as all of them
try to do some smart terminal line-rewrite to show some sort
of percentage, but when they compile all in parallel it is pretty
messy.

Signed-off-by: Henner Zeller <h.zeller@acm.org>