### PR TITLE
Test fixes3

### DIFF
--- a/tests/chapter-9/9.4.2.1--event_comma_op.sv
+++ b/tests/chapter-9/9.4.2.1--event_comma_op.sv
@@ -9,7 +9,7 @@ module block_tb ();
 	wire b = 0;
 	wire c = 0;
 	wire d = 0;
-	wire out = 0;
+	reg out;
 	always @(a, b, c, d)
 		out = (a | b) & (c | d);
 endmodule

--- a/tests/chapter-9/9.4.2.1--event_or_op.sv
+++ b/tests/chapter-9/9.4.2.1--event_or_op.sv
@@ -9,7 +9,7 @@ module block_tb ();
 	wire b = 0;
 	wire c = 0;
 	wire d = 0;
-	wire out = 0;
+	reg out;
 	always @(a or b or c or d)
 		out = (a | b) & (c | d);
 endmodule

--- a/tests/chapter-9/9.4.2.2--event_implicit.sv
+++ b/tests/chapter-9/9.4.2.2--event_implicit.sv
@@ -9,7 +9,7 @@ module block_tb ();
 	wire b = 0;
 	wire c = 0;
 	wire d = 0;
-	wire out = 0;
+	reg out;
 	always @(*)
 		out = (a | b) & (c | d);
 endmodule

--- a/tests/chapter-9/9.4.2.3--event_conditional.sv
+++ b/tests/chapter-9/9.4.2.3--event_conditional.sv
@@ -8,7 +8,7 @@ module block_tb ();
 	wire clk = 0;
 	wire en = 0;
 	wire a = 0;
-	reg y = 0;
+	reg y;
 	always @(posedge clk iff en == 1)
 		y <= a;
 endmodule

--- a/tests/generic/number/number_test_63.sv
+++ b/tests/generic/number/number_test_63.sv
@@ -1,7 +1,0 @@
-/*
-:name: number_test_63
-:description: Hex literal with invalid leading underscore prefix should fail.
-:should_fail: 1
-:tags: 5.6.4 5.7.1 5.7.2
-*/
-timeunit _23_ns;


### PR DESCRIPTION
9.4.2.1--event_comma_op, etc: Fix illegal procedural assignment to wire.

generic/number/number_test_63: Remove, not testing what was intended.

