### PR TITLE
Fix typedef_test_9 etc: Declare types before use as required by IEEE.

### DIFF
--- a/tests/generic/typedef/typedef_test_10.sv
+++ b/tests/generic/typedef/typedef_test_10.sv
@@ -4,4 +4,6 @@
 :should_fail: 0
 :tags: 6.18
 */
+typedef bit data_t;
+
 typedef data_t my_array_t [ * ];

--- a/tests/generic/typedef/typedef_test_11.sv
+++ b/tests/generic/typedef/typedef_test_11.sv
@@ -4,4 +4,6 @@
 :should_fail: 0
 :tags: 6.18
 */
+typedef bit data_t;
+
 typedef data_t my_array_t [bit];

--- a/tests/generic/typedef/typedef_test_12.sv
+++ b/tests/generic/typedef/typedef_test_12.sv
@@ -4,4 +4,6 @@
 :should_fail: 0
 :tags: 6.18
 */
+typedef bit data_t;
+
 typedef data_t my_array_t [bit[31:0]];

--- a/tests/generic/typedef/typedef_test_13.sv
+++ b/tests/generic/typedef/typedef_test_13.sv
@@ -4,4 +4,9 @@
 :should_fail: 0
 :tags: 6.18
 */
+typedef bit data_t;
+parameter k = 6;
+parameter j = 5;
+parameter l = 2;
+
 typedef data_t my_ar_t [bit[31:0][k:0]][bit[j:0][l:0]];

--- a/tests/generic/typedef/typedef_test_14.sv
+++ b/tests/generic/typedef/typedef_test_14.sv
@@ -4,4 +4,8 @@
 :should_fail: 0
 :tags: 6.18
 */
+package some_package;
+   typedef bit some_type;
+endpackage
+
 typedef some_package::some_type myalias;

--- a/tests/generic/typedef/typedef_test_18.sv
+++ b/tests/generic/typedef/typedef_test_18.sv
@@ -4,7 +4,9 @@
 :should_fail: 0
 :tags: 6.18
 */
+parameter K = 9;
+
 typedef struct {
   rand bit i;
-  randc integer b[k:0];
+  randc integer b[K:0];
 } randstruct;

--- a/tests/generic/typedef/typedef_test_9.sv
+++ b/tests/generic/typedef/typedef_test_9.sv
@@ -4,4 +4,8 @@
 :should_fail: 0
 :tags: 6.18
 */
+parameter j = 3;
+parameter k = 2;
+typedef bit data_t;
+
 typedef data_t my_array_t [k:0][j:0];


### PR DESCRIPTION
Declares types before use as required by IEEE.
