### PR TITLE
Don't run tests that are disabled every time.

### DIFF
--- a/tools/runner
+++ b/tools/runner
@@ -135,6 +135,9 @@ test_params['mode'] = runner_obj.get_mode(test_params['type'].split())
 
 if test_params['mode'] is None:
     logger.info("Skipping {}/{}".format(args.runner, args.test))
+    with open(out, "w") as f:
+      f.write("")  # runner does not support mode; just mark file as handled.
+
     sys.exit(0)
 
 try:

--- a/tools/runner
+++ b/tools/runner
@@ -136,7 +136,7 @@ test_params['mode'] = runner_obj.get_mode(test_params['type'].split())
 if test_params['mode'] is None:
     logger.info("Skipping {}/{}".format(args.runner, args.test))
     with open(out, "w") as f:
-      f.write("")  # runner does not support mode; just mark file as handled.
+        f.write("")  # runner does not support mode; just mark file as handled.
 
     sys.exit(0)
 

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -246,7 +246,7 @@ def collect_logs(runner_name):
 
         # Tests that have not run will have an existing, but empty logfile.
         if os.path.getsize(t) == 0:
-          continue
+            continue
 
         tests[t_id] = {}
 

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -244,6 +244,10 @@ def collect_logs(runner_name):
         t_id = t[len(args.logs) + 1:]
         logger.debug("Found log: " + t_id)
 
+        # Tests that have not run will have an existing, but empty logfile.
+        if os.path.getsize(t) == 0:
+          continue
+
         tests[t_id] = {}
 
         test_tags = [


### PR DESCRIPTION
Not all tests are run, e.g. tests for simulation are not
run by runners that only can do preprocessing.

Previously, these tests didn't generate any logfiles, so were
considered by the Makefile to re-run every time as the Makefile
considers the logfile as output. As a result, make never
considered the output as 'complete'.

Fix this by creating an empty logfile in that case and properly
skip these in the report generation.

Signed-off-by: Henner Zeller <h.zeller@acm.org>