### PR TITLE
kokoro: Push the sv-tests report result to GitHub.

### DIFF
--- a/.github/kokoro/continuous.cfg
+++ b/.github/kokoro/continuous.cfg
@@ -4,6 +4,15 @@ build_file: "sv-tests/.github/kokoro/run.sh"
 
 timeout_mins: 4320
 
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74045
+      keyname: "foss-fpga-tools_sv-tests_ssh_private"
+    }
+  }
+}
+
 action {
   define_artifacts {
     regex: "**/out/report/**"

--- a/.github/kokoro/steps/hostsetup.sh
+++ b/.github/kokoro/steps/hostsetup.sh
@@ -43,3 +43,58 @@ echo "----------------------------------------"
 sudo cgcreate -a $(whoami) -t $(whoami) -g memory,cpu:sv-tests
 ls -l /sys/fs/cgroup/*/sv-tests
 echo "----------------------------------------"
+
+
+if [[ $KOKORO_TYPE = continuous ]]; then
+	echo
+	echo "========================================"
+	echo "Accessible secrets"
+	echo "----------------------------------------"
+	find $KOKORO_KEYSTORE_DIR
+
+	echo
+	echo "Configuring SSH client"
+	echo "----------------------------------------"
+	mkdir -p ~/.ssh
+	chmod 700 ~/.ssh
+	find ~/.ssh
+
+	cat ~/.ssh/config || true
+	cat > ~/.ssh/config <<EOF
+Host *
+	BatchMode yes
+	StrictHostKeyChecking no
+	CheckHostIP no
+	UserKnownHostsFile /dev/null
+
+Host github.com
+	User git
+EOF
+	chmod 600 ~/.ssh/config
+
+	echo
+	echo "Starting SSH agent and adding keys"
+	echo "----------------------------------------"
+	eval $(ssh-agent)
+	ssh-add -l || true
+	for KEY in $KOKORO_KEYSTORE_DIR/*; do
+		chmod 600 $KEY
+		ssh-add $KEY
+	done
+	ssh-add -l || true
+	ssh-add -L || true
+
+	echo
+	echo "Testing connection to GitHub"
+	echo "----------------------------------------"
+	ssh -v git@github.com 2>&1 | tee /tmp/github.login
+	if grep -q "successfully authenticated" /tmp/github.login; then
+		echo "Successfully connected to GitHub!"
+	else
+		echo "Issue connecting to GitHub!"
+		echo ":-("
+		exit 1
+	fi
+	echo
+	echo "----------------------------------------"
+fi


### PR DESCRIPTION
Run all tests on Kokoro and then publish the results onto the `gh-pages` branch using
the SSH key pair stored in the Kokoro keystore.

Signed-off-by: Tim 'mithro' Ansell <me@mith.ro>