### PR TITLE
slang runner: Set correct flag for preprocessing mode, use simple compilation unit mode

### DIFF
--- a/tools/runners/Slang.py
+++ b/tools/runners/Slang.py
@@ -3,7 +3,7 @@ from BaseRunner import BaseRunner
 
 class Slang(BaseRunner):
     def __init__(self):
-        super().__init__("slang", "slang-driver")
+        super().__init__("slang", "slang-driver", {"preprocessing", "parsing"})
 
         self.url = "https://github.com/MikePopoloski/slang"
 
@@ -13,6 +13,10 @@ class Slang(BaseRunner):
         self.cmd = [self.executable]
         if mode == 'preprocessing':
             self.cmd += ['-E']
+
+        # Some tests expect that all input files will be concatenated into
+        # a single compilation unit, so ask slang to do that.
+        self.cmd += ['--single-unit']
 
         for incdir in params['incdirs']:
             self.cmd.append('-I' + incdir)

--- a/tools/runners/Slang.py
+++ b/tools/runners/Slang.py
@@ -3,12 +3,16 @@ from BaseRunner import BaseRunner
 
 class Slang(BaseRunner):
     def __init__(self):
-        super().__init__("slang", "slang-driver", {"preprocessing", "parsing"})
+        super().__init__("slang", "slang-driver")
 
         self.url = "https://github.com/MikePopoloski/slang"
 
     def prepare_run_cb(self, tmp_dir, params):
+        mode = params['mode']
+
         self.cmd = [self.executable]
+        if mode == 'preprocessing':
+            self.cmd += ['-E']
 
         for incdir in params['incdirs']:
             self.cmd.append('-I' + incdir)


### PR DESCRIPTION
slang supports full elaboration, no need to restrict to just parsing and preprocessing.

When running in preprocessing mode, where tests don't expect to be fully compilable, use the -E flag to only preprocess.