### PR TITLE
5.9-string-word-assignment: Fix single-bit assignment.

### DIFF
--- a/tests/chapter-5/5.9-string-word-assignment.sv
+++ b/tests/chapter-5/5.9-string-word-assignment.sv
@@ -5,7 +5,9 @@
 :tags: 5.9
 */
 module top();
-  bit   a[8 * 3 : 0] = "hi0";
+  bit [8 * 3 - 1 : 0] a = "hi0";
+  // Note as of January 2020 several commercial simulators do not support unpacked byte
+  // assignment from strings:
   byte      b[3 : 0] = "hi2";
 
 endmodule


### PR DESCRIPTION
IEEE says assignment to *packed* or a unpacked array of bytes is legal, not an *unpacked* bit array.
