### PR TITLE
Fix Verilator driver to not false-fail when $time used

### DIFF
--- a/conf/runners/vmain.cpp
+++ b/conf/runners/vmain.cpp
@@ -5,13 +5,17 @@
 #include <verilated.h>
 #include <Vtop.h>
 
+vluint64_t main_time = 0;
+double sc_time_stamp() { return main_time; }
+
 int main(int argc, char *argv[]) {
 	Verilated::commandArgs(argc, argv);
 
 	Vtop *top = new Vtop;
 
-	for (int i = 0; i < 1000 && !Verilated::gotFinish(); i++)
+	for (; main_time < 1000 && !Verilated::gotFinish(); ++main_time) {
 		top->eval();
+	}
 
 	top->final();
 


### PR DESCRIPTION
Fixes an issue in the test harness which was false failing any test on verilator using $time indirectly e.g.  20.10--info.sv