### PR TITLE
Fix $error/fatal/warning to be non-simulator.

### DIFF
--- a/tests/chapter-20/20.10--error.sv
+++ b/tests/chapter-20/20.10--error.sv
@@ -3,7 +3,9 @@
 :description: $error test
 :should_fail: 0
 :tags: 20.10
-:type: simulation parsing
+:type: parsing
+  Note this is not a simulation test, as the $warning may result in some
+  simulators returning bad exit status.
 */
 
 module top();

--- a/tests/chapter-20/20.10--fatal.sv
+++ b/tests/chapter-20/20.10--fatal.sv
@@ -3,7 +3,9 @@
 :description: $fatal test
 :should_fail: 0
 :tags: 20.10
-:type: simulation parsing
+:type: parsing
+  Note this is not a simulation test, as the $warning may result in some
+  simulators returning bad exit status.
 */
 
 module top();

--- a/tests/chapter-20/20.10--warning.sv
+++ b/tests/chapter-20/20.10--warning.sv
@@ -3,7 +3,9 @@
 :description: $warning test
 :should_fail: 0
 :tags: 20.10
-:type: simulation parsing
+:type: parsing
+  Note this is not a simulation test, as the $warning may result in some
+  simulators returning bad exit status.
 */
 
 module top();


### PR DESCRIPTION
Once pull #592 is applied, Verilator is false-failed out on
* tests/chapter-20/20.10--error.sv
* tests/chapter-20/20.10--fatal.sv
* tests/chapter-20/20.10--warning.sv

because these tests are themselves creating errors.  Likewise Icarus is false-failed on $error.  The various parsers consider everything fine.  The difference is in policies on what returns bad exit status.

This pull makes them non-simulator tests, as this seemed the best route to have them indeterminate.

The $info test remains simulation, as never should fail.
