### PR TITLE
conf: fix encapsulation test template

### DIFF
--- a/conf/generators/templates/encapsulation.json
+++ b/conf/generators/templates/encapsulation.json
@@ -7,7 +7,7 @@
 		":description: encapsulation test",
 		":should_fail: {1}",
 		":tags: 8.18",
-		":type: {3}",
+		":type: {4}",
 		"*/",
 		"module top();",
 		"class a_cls;",


### PR DESCRIPTION
This PR fixes the issue with not generating logs for encapsulation tests mentioned in #437 
It appears that wrong column was used for `:type:` field