### PR TITLE
tools/runner: add option to keep runner work directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,14 @@ else
 $(OUT_DIR)/logs/$(1)/$(2).log : RUNNER = ./tools/runner
 endif
 
+ifneq ($(RUNNER_KEEP_TMP),)
+RUNNER_PARAM := --keep-tmp
+else
+RUNNER_PARAM := --quiet
+endif
+
 $(OUT_DIR)/logs/$(1)/$(2).log: $(TESTS_DIR)/$(2) | $(1)-cg
-	$$(RUNNER) --runner $(1) --test $(2) --out $(OUT_DIR)/logs/$(1)/$(2).log --quiet
+	$$(RUNNER) --runner $(1) --test $(2) --out $(OUT_DIR)/logs/$(1)/$(2).log $(RUNNER_PARAM)
 
 tests: $(OUT_DIR)/logs/$(1)/$(2).log
 

--- a/tools/runner
+++ b/tools/runner
@@ -19,6 +19,7 @@ action.add_argument("-t", "--test")
 action.add_argument("-v", "--version", action="store_true")
 
 parser.add_argument("-o", "--out", required=True)
+parser.add_argument("-k", "--keep-tmp", action="store_true")
 
 parser.add_argument(
     "-q",
@@ -191,4 +192,9 @@ except Exception as e:
             args.runner, args.test, str(e)))
     sys.exit(1)
 finally:
-    shutil.rmtree(tmp_dir)
+    if args.keep_tmp:
+        logger.info(
+            "{}/{} work directory was left for inspection {}".format(
+                args.runner, args.test, tmp_dir))
+    else:
+        shutil.rmtree(tmp_dir)


### PR DESCRIPTION
As suggested in #445 this adds option to keep the directories in `/tmp` by setting `RUNNER_KEEP_TMP` variable