### PR TITLE
Tests: Fix slice-equality and assignment expectations

### DIFF
--- a/tests/chapter-7/arrays/packed/slice-equality.sv
+++ b/tests/chapter-7/arrays/packed/slice-equality.sv
@@ -13,7 +13,7 @@ bit [7:0] arr_b;
 initial begin
 	arr_a = 8'hf0;
 	arr_b = 8'h0f;
-	$display(":assert: (('%h' == 'ff') and ('%h' == 'ff'))", arr_a, arr_b);
+	$display(":assert: (('%h' == 'f0') and ('%h' == '0f'))", arr_a, arr_b);
 
 	$display(":assert: (%d == 1)", (arr_a[7:4] == arr_b[3:0]));
 	$display(":assert: (%d == 0)", (arr_a[7:4] != arr_b[3:0]));

--- a/tests/chapter-8/8.10--static_methods.sv
+++ b/tests/chapter-8/8.10--static_methods.sv
@@ -8,7 +8,8 @@ module class_tb ();
 	class test_cls;
 		static int id = 0;
 		static function int next_id();
-			next_id = ++id;
+			++id;
+			next_id = id;
 		endfunction
 	endclass
 

--- a/tests/chapter-8/8.13--inheritance.sv
+++ b/tests/chapter-8/8.13--inheritance.sv
@@ -8,7 +8,8 @@ module class_tb ();
 	class super_cls;
 		int s = 2;
 		function int incs();
-			incs = ++s;
+			++s;
+			incs = s;
 		endfunction
 		function new(int def = 3);
 			s = def;

--- a/tests/chapter-8/8.14--override_member.sv
+++ b/tests/chapter-8/8.14--override_member.sv
@@ -8,7 +8,8 @@ module class_tb ();
 	class super_cls;
 		int s = 2;
 		function int incs();
-			incs = ++s;
+			++s
+			incs = s;
 		endfunction
 		function new(int def = 3);
 			s = def;

--- a/tests/chapter-8/8.15--super.sv
+++ b/tests/chapter-8/8.15--super.sv
@@ -8,7 +8,8 @@ module class_tb ();
 	class super_cls;
 		int s = 2;
 		function int incs();
-			incs = ++s;
+			++s;
+			incs = s;
 		endfunction
 		function new(int def = 3);
 			s = def;

--- a/tests/chapter-8/8.23--scope_resolution.sv
+++ b/tests/chapter-8/8.23--scope_resolution.sv
@@ -8,7 +8,8 @@ module class_tb ();
 	class test_cls;
 		static int id = 0;
 		static function int next_id();
-			next_id = ++id;
+			++id;
+			next_id = id;
 		endfunction
 	endclass
 


### PR DESCRIPTION
Fix some tests.
* slice-equality: Fix wrong expectation.
* chapter-8: These tests should mostly test the feature they describe and not fail if assignment-within-expression is unsupported, for which there is already a separate test.
