### PR TITLE
Add equality check for escaped identifiers

### DIFF
--- a/tests/chapter-5/5.6.1--nonescaped-access.sv
+++ b/tests/chapter-5/5.6.1--nonescaped-access.sv
@@ -1,0 +1,15 @@
+/*
+:name: nonescaped-access
+:description: Escaped identifiers can be referenced by nonescaped name
+:should_fail: 0
+:tags: 5.6.1
+*/
+`default_nettype none
+module identifiers();
+
+  reg \cpu3 ;
+  wire reference_test;
+
+  assign reference_test = cpu3;
+
+endmodule


### PR DESCRIPTION
Not exactly sure if the following is correct, and also if the test makes sense.
Therefore, it would be nice the get feedback from people who are more experienced with the spec.

Following the description of Chapter 5.6.1 the backslash or following
white space is not part of the identifier.
As an example the escaped identifier `\cpu3` is the same as the
nonescaped identifier `cpu3`.

Add an escaped identifier and use it nonescaped.
Escalate the undefined usage to an error.