### PR TITLE
Only calculate throughput for larger tests.

### DIFF
--- a/conf/report/report-template.html
+++ b/conf/report/report-template.html
@@ -156,10 +156,10 @@
           {% endfor %}
         </tr>
 	<tr class="report_summary_row">
-          <th class="report_table_info" colspan="2"> Average throughput passed: </th>
+          <th class="report_table_info" colspan="2"> Average throughput passed for inputs &gt; 1KiB </th>
           {% for tool, tooldata in report|dictsort %}
           <th class="report_table_result" title="{{ tool.lower() }}" >
-            {{'%0.2f'| format(report[tool]["passed_throughput"]|float)}} KB/s </th>
+            {{'%0.0f'| format(report[tool]["passed_throughput"]|float)}} KiB/s </th>
           {% endfor %}
         </tr>
       </tfoot>

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -62,6 +62,11 @@ parser.add_argument(
 parser.add_argument(
     "-r", "--revision", help="Report revision", default="unknown")
 
+# We only consider tests with minimum this size for the throughput
+# calculation, so that we skip the super-tiny few-line tests that are
+# not a true reflection of a common usage.
+minimum_throughput_file_size = 1024
+
 # parse args
 args = parser.parse_args()
 
@@ -317,9 +322,11 @@ def collect_logs(runner_name):
             tests[t_id]["first_file"] = logToHTML(t, t_html, tests[t_id])
 
             if tests[t_id]["status"] == "test-passed":
-                runner_data["passed_time"] += float(
-                    tests[t_id]["time_elapsed"])
-                runner_data["passed_size"] += float(totalSize(tests[t_id]))
+                test_file_size = float(totalSize(tests[t_id]))
+                if test_file_size > minimum_throughput_file_size:
+                    runner_data["passed_time"] += float(
+                        tests[t_id]["time_elapsed"])
+                    runner_data["passed_size"] += test_file_size
 
             runner_data["time_elapsed"] += float(tests[t_id]["time_elapsed"])
             runner_data["user_time"] += float(tests[t_id]["user_time"])


### PR DESCRIPTION
The throughput calculation makes more sense for files that are more
than just a few lines (like many of the LRM tests), so only include
tests in the throughput calculation that are at least 1KiB.

In the output, round the calculated throughput to full kibibytes/s; the
double-digit post-decimal point resolution is more accurate than
noise will allow.

Signed-off-by: Henner Zeller <h.zeller@acm.org>