### PR TITLE
tests: fix always block to use sensitivity lists

### DIFF
--- a/tests/chapter-12/12.4--if.sv
+++ b/tests/chapter-12/12.4--if.sv
@@ -7,7 +7,7 @@
 module if_tb ();
 	wire a = 0;
 	reg b = 0;
-	always begin
+	always @* begin
 		if(a) b = 1;
 	end
 endmodule

--- a/tests/chapter-12/12.4--if_else.sv
+++ b/tests/chapter-12/12.4--if_else.sv
@@ -7,7 +7,7 @@
 module if_tb ();
 	wire a = 0;
 	reg b = 0;
-	always begin
+	always @* begin
 		if(a) b = 1;
 		else b = 0;
 	end

--- a/tests/chapter-12/12.4.1--if_else_if.sv
+++ b/tests/chapter-12/12.4.1--if_else_if.sv
@@ -9,7 +9,7 @@ module if_tb ();
 	reg b = 0;
 	wire c = 0;
 	reg d = 0;
-	always begin
+	always @* begin
 		if(a) b = 1;
 		else if(c) d = 1;
 		else b = 0;

--- a/tests/chapter-12/12.4.2--priority_if.sv
+++ b/tests/chapter-12/12.4.2--priority_if.sv
@@ -7,7 +7,7 @@
 module if_tb ();
 	wire [3:0] a = 0;
 	reg [1:0] b = 0;
-	always begin
+	always @* begin
 		priority if(a[0] == 0) b = 1;
 		else if(a[1] == 0) b = 2;
 	end

--- a/tests/chapter-12/12.4.2--unique0_if.sv
+++ b/tests/chapter-12/12.4.2--unique0_if.sv
@@ -7,7 +7,7 @@
 module if_tb ();
 	wire [3:0] a = 0;
 	reg [1:0] b = 0;
-	always begin
+	always @* begin
 		unique0 if(a == 0) b = 1;
 		else if(a == 1) b = 2;
 	end

--- a/tests/chapter-12/12.4.2--unique_if.sv
+++ b/tests/chapter-12/12.4.2--unique_if.sv
@@ -7,7 +7,7 @@
 module if_tb ();
 	wire [3:0] a = 0;
 	reg [1:0] b = 0;
-	always begin
+	always @* begin
 		unique if(a == 0) b = 1;
 		else if(a == 1) b = 2;
 	end

--- a/tests/chapter-12/12.5--case.sv
+++ b/tests/chapter-12/12.5--case.sv
@@ -7,7 +7,7 @@
 module case_tb ();
 	wire [3:0] a = 0;
 	reg [3:0] b = 0;
-	always begin
+	always @* begin
 		case(a)
 			4'h0: b = 12;
 			4'h3: b = 4;

--- a/tests/chapter-12/12.5.1--casex.sv
+++ b/tests/chapter-12/12.5.1--casex.sv
@@ -7,7 +7,7 @@
 module case_tb ();
 	wire [3:0] a = 4'b10zx;
 	reg [3:0] b = 0;
-	always begin
+	always @* begin
 		casex(a)
 			4'b1xz?: b = 1;
 			4'b01xx: b = 2;

--- a/tests/chapter-12/12.5.1--casez.sv
+++ b/tests/chapter-12/12.5.1--casez.sv
@@ -7,7 +7,7 @@
 module case_tb ();
 	wire [3:0] a = 4'b1z11;
 	reg [3:0] b = 0;
-	always begin
+	always @* begin
 		casez(a)
 			4'b1zzz: b = 1;
 			4'b01z?: b = 2;

--- a/tests/chapter-12/12.5.2--case_const.sv
+++ b/tests/chapter-12/12.5.2--case_const.sv
@@ -7,7 +7,7 @@
 module case_tb ();
 	wire [3:0] a = 0;
 	reg [3:0] b = 0;
-	always begin
+	always @* begin
 		case(1)
 			a[0] : b = 1;
 			a[1] : b = 2;

--- a/tests/chapter-12/12.5.4--case_set.sv
+++ b/tests/chapter-12/12.5.4--case_set.sv
@@ -7,7 +7,7 @@
 module case_tb ();
 	reg [3:0] a = 0;
 	reg [3:0] b = 0;
-	always begin
+	always @* begin
 		case(a) inside
 			1, 3: b = 1;
 			4'b01??, [5:6]: b = 2;


### PR DESCRIPTION
As pointed out in #138 some `always` blocks were infinite loops, this PR aims to fix those cases