### PR TITLE
Disable Python feature when invoking surelog.

### DIFF
--- a/tools/runners/Surelog.py
+++ b/tools/runners/Surelog.py
@@ -8,7 +8,9 @@ class Surelog(BaseRunner):
         self.url = "https://github.com/alainmarcel/Surelog"
 
     def prepare_run_cb(self, tmp_dir, params):
-        self.cmd = [self.executable, '-nopython', '-nobuiltin', '-parse', '-noelab']
+        self.cmd = [
+            self.executable, '-nopython', '-nobuiltin', '-parse', '-noelab'
+        ]
 
         for incdir in params['incdirs']:
             self.cmd.append('-I' + incdir)

--- a/tools/runners/Surelog.py
+++ b/tools/runners/Surelog.py
@@ -8,7 +8,7 @@ class Surelog(BaseRunner):
         self.url = "https://github.com/alainmarcel/Surelog"
 
     def prepare_run_cb(self, tmp_dir, params):
-        self.cmd = [self.executable, '-nobuiltin', '-parse', '-noelab']
+        self.cmd = [self.executable, '-nopython', '-nobuiltin', '-parse', '-noelab']
 
         for incdir in params['incdirs']:
             self.cmd.append('-I' + incdir)


### PR DESCRIPTION
The Python-API is somewhat expensive to initialize. This reduces
the overall runtime of Surelog parsing by a few hundred seconds.

Signed-off-by: Henner Zeller <h.zeller@acm.org>