### PR TITLE
For some larger tests: give a little more timeout-slack to slow tools.

### DIFF
--- a/generators/ariane
+++ b/generators/ariane
@@ -11,7 +11,7 @@ templ = """/*
 :should_fail: 0
 :tags: ariane
 :top_module: ariane_testharness
-:timeout: 100
+:timeout: 180
 */
 """
 

--- a/generators/earlgrey
+++ b/generators/earlgrey
@@ -11,7 +11,7 @@ templ = """/*
 :incdirs: {1}
 :should_fail: 0
 :tags: earlgrey
-:timeout: 100
+:timeout: 180
 :top_module: top_earlgrey_nexysvideo
 */
 """

--- a/tools/BaseRunner.py
+++ b/tools/BaseRunner.py
@@ -114,7 +114,7 @@ class BaseRunner:
             kill_child_processes(proc.pid)
             proc.kill()
             proc.communicate()
-            log = "Timeout".encode('utf-8')
+            log = ("Timeout: > " + params['timeout'] + "s").encode('utf-8')
             returncode = 1
 
         return (self.transform_log(log.decode('utf-8')), returncode)


### PR DESCRIPTION
Also: Print what the actual timeout was in the log.

Signed-off-by: Henner Zeller <h.zeller@acm.org>