### PR TITLE
Provide a runner function that returns if a tool return code

### DIFF
--- a/conf/report/log-template.html
+++ b/conf/report/log-template.html
@@ -9,6 +9,7 @@
 <h3><a href="{{runner_url}}" target="_blank">{{runner}}</a></h3>
 <pre class="{{status}}">
 description: {{description|e}}
+rc: {{rc|e}} (means success: {{tool_success|e}})
 should_fail: {{should_fail|e}}
 tags: {{tags|e}}
 incdirs: {{incdirs|e}}

--- a/tools/BaseRunner.py
+++ b/tools/BaseRunner.py
@@ -119,6 +119,15 @@ class BaseRunner:
 
         return (self.transform_log(log.decode('utf-8')), returncode)
 
+    def is_success_returncode(self, rc, params):
+        """ Returns a boolean if the given returncode is considered a success.
+
+        This function determines if the tool was running successfully. Tools
+        might return more rich return codes, so not all non-zero codes might
+        mean failure.
+        """
+        return rc == 0
+
     def transform_log(self, output):
         """ Post-process the output log
 

--- a/tools/runner
+++ b/tools/runner
@@ -154,7 +154,9 @@ try:
     output, rc, user_time, system_time, ram_usage = runner_obj.run(
         tmp_dir, test_params)
 
+    tool_success = runner_obj.is_success_returncode(rc, test_params)
     test_params['rc'] = rc
+    test_params['tool_success'] = "1" if tool_success else "0"
     test_params['runner'] = runner_obj.name
     test_params['runner_url'] = runner_obj.url
     test_params['time_elapsed'] = str(user_time + system_time)
@@ -163,9 +165,10 @@ try:
     test_params['ram_usage'] = ram_usage
 
     tool_should_fail = test_params["should_fail"] == "1"
-    tool_failed = test_params["rc"] != 0
+    tool_failed = not tool_success
+    tool_crashed = rc >= 126
 
-    test_passed = rc < 126 and tool_should_fail == tool_failed
+    test_passed = not tool_crashed and tool_should_fail == tool_failed
 
     if test_passed and test_params['mode'] == 'simulation':
         test_passed = parseLog(output)

--- a/tools/runners/Surelog.py
+++ b/tools/runners/Surelog.py
@@ -16,3 +16,8 @@ class Surelog(BaseRunner):
             self.cmd.append('-I' + incdir)
 
         self.cmd += params['files']
+
+    def is_success_returncode(self, rc, params):
+        # 1 << 4 means semantic error, but we're only interested in
+        # syntax and fatal errors.
+        return rc & 0x03 == 0

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -268,7 +268,8 @@ def collect_logs(runner_name):
         test_tags = [
             "name", "tags", "should_fail", "rc", "description", "files",
             "incdirs", "top_module", "runner", "runner_url", "time_elapsed",
-            "type", "mode", "timeout", "user_time", "system_time", "ram_usage"
+            "type", "mode", "timeout", "user_time", "system_time", "ram_usage",
+            "tool_success"
         ]
         with open(t, "r") as f:
             try:
@@ -306,8 +307,9 @@ def collect_logs(runner_name):
 
             tool_should_fail = tests[t_id]["should_fail"] == "1"
             tool_rc = int(tests[t_id]["rc"])
-            tool_failed = (tool_rc != 0)
-            if tool_rc >= 126 or tool_should_fail != tool_failed:
+            tool_crashed = tool_rc >= 126
+            tool_failed = tests[t_id]["tool_success"] == "0"
+            if tool_crashed or tool_should_fail != tool_failed:
                 tests[t_id]["status"] = "test-failed"
             elif tests[t_id]["mode"] == 'simulation' and not parseLog(
                     tests[t_id]["log"]):


### PR DESCRIPTION
was successful. Use for filtering Surelog return codes.

Fixes #663

Signed-off-by: Henner Zeller <h.zeller@acm.org>