### PR TITLE
Various test fixes

### DIFF
--- a/tests/chapter-22/22.4--include_basic.sv
+++ b/tests/chapter-22/22.4--include_basic.sv
@@ -5,6 +5,6 @@
 :tags: 22.4
 :type: preprocessing parsing
 */
-`include <dummy_include.sv>
+`include "dummy_include.sv"
 module top ();
 endmodule

--- a/tests/chapter-22/22.4--include_with_comment.sv
+++ b/tests/chapter-22/22.4--include_with_comment.sv
@@ -5,6 +5,6 @@
 :tags: 22.4
 :type: preprocessing parsing
 */
-`include <dummy_include.sv> // comments after `include are perfectly legal
+`include "dummy_include.sv" // comments after `include are perfectly legal
 module top ();
 endmodule

--- a/tests/chapter-6/6.19--enum_value_inv.sv
+++ b/tests/chapter-6/6.19--enum_value_inv.sv
@@ -1,0 +1,16 @@
+/*
+:name: enum_value_inv
+:description: Tests that tools diagnose invalid enum value assignments
+:should_fail: 1
+:tags: 6.19
+*/
+module top();
+	// 6.19 says:
+	// If the integer value expression is a sized literal constant, it shall
+	// be an error if the size is different from the enum base type, even if
+	// the value is within the representable range.
+	enum logic [2:0] {
+	  Global = 4'h2,
+	  Local = 4'h3
+	} myenum;
+endmodule

--- a/tests/generic/enum/enum_test_0.sv
+++ b/tests/generic/enum/enum_test_0.sv
@@ -5,3 +5,5 @@
 :tags: 6.19
 */
 typedef enum myenum_fwd;
+
+typedef enum { A, B } myenum_fwd;

--- a/tests/generic/struct/struct_test_0.sv
+++ b/tests/generic/struct/struct_test_0.sv
@@ -5,3 +5,5 @@
 :tags: 7.2
 */
 typedef struct mystruct_fwd;
+
+typedef struct { logic a; logic b; } mystruct_fwd;

--- a/tests/generic/typedef/typedef_test_0.sv
+++ b/tests/generic/typedef/typedef_test_0.sv
@@ -5,3 +5,9 @@
 :tags: 6.18
 */
 typedef i_am_a_type_really;
+
+typedef int i_am_a_type_really;
+
+// Multiple forward typedefs are allowed.
+typedef i_am_a_type_really;
+typedef i_am_a_type_really;

--- a/tests/generic/typedef/typedef_test_19.sv
+++ b/tests/generic/typedef/typedef_test_19.sv
@@ -4,7 +4,7 @@
 :should_fail: 0
 :tags: 6.18
 */
-typedef enum logic {
-  Global = 4'h2,
-  Local = 4'h3
+typedef enum {
+  Global = 2,
+  Local = 3
 } myenum_fwd;

--- a/tests/generic/typedef/typedef_test_22.sv
+++ b/tests/generic/typedef/typedef_test_22.sv
@@ -6,6 +6,6 @@
 */
 typedef enum uvec8_t;
 typedef enum {
-  Global = 4'h2,
-  Local = 4'h3
+  Global = 2,
+  Local = 3
 } uvec8_t;

--- a/tests/generic/typedef/typedef_test_26.sv
+++ b/tests/generic/typedef/typedef_test_26.sv
@@ -6,9 +6,9 @@
 */
 typedef enum {
 `ifdef TWO
-  Global = 4'h2,
+  Global = 2,
 `else
-  Global = 4'h1,
+  Global = 1,
 `endif
-  Local = 4'h3
+  Local = 3
 } myenum_fwd;

--- a/tests/generic/typedef/typedef_test_27.sv
+++ b/tests/generic/typedef/typedef_test_27.sv
@@ -5,10 +5,10 @@
 :tags: 6.18
 */
 typedef enum {
-  Global = 4'h2,
+  Global = 2,
 `ifdef TWO
-  Local = 4'h2
+  Local = 2
 `else
-  Local = 4'h1
+  Local = 1
 `endif
 } myenum_fwd;

--- a/tests/generic/typedef/typedef_test_28__bad.sv
+++ b/tests/generic/typedef/typedef_test_28__bad.sv
@@ -1,0 +1,13 @@
+/*
+:name: typedef_test_28
+:description: Test
+:should_fail: 1
+:tags: 6.18
+*/
+
+// 6.18 says:
+// The actual data type definition of a forward typedef declaration shall
+// be resolved within the same localscope or generate block. It shall be an
+// error if the type_identifier does not resolve to a data type.
+
+typedef missing_forward_typedef;

--- a/tests/generic/union/union_test_0.sv
+++ b/tests/generic/union/union_test_0.sv
@@ -5,3 +5,5 @@
 :tags: 7.3
 */
 typedef union myunion_fwd;
+
+typedef union { logic a; logic b; } myunion_fwd;


### PR DESCRIPTION
Things being fixed here:
* The spec says angle bracket includes only search for files provided by the language implementation, not the user's directories or the compiler's working directory.
* The spec says forward typedefs must resolve to a type within the same scope. 
* The spec says enum value initializers that use sized constants must match the size of the enum's base type.

In addition to fixing the existing tests, I added some additional coverage to catch the invalid cases mentioned above.