### PR TITLE
support should_fail_because tag

### DIFF
--- a/conf/report/log-template.html
+++ b/conf/report/log-template.html
@@ -10,8 +10,11 @@
 <pre class="{{status}}">
 description: {{description|e}}
 rc: {{rc|e}} (means success: {{tool_success|e}})
+{% if should_fail_because|length %}
+should_fail_because: {{should_fail_because|e}}
+{% else %}
 should_fail: {{should_fail|e}}
-fail_reason: {{should_fail_because|e}}
+{% endif %}
 tags: {{tags|e}}
 incdirs: {{incdirs|e}}
 top_module: {{top_module|e}}

--- a/conf/report/log-template.html
+++ b/conf/report/log-template.html
@@ -11,6 +11,7 @@
 description: {{description|e}}
 rc: {{rc|e}} (means success: {{tool_success|e}})
 should_fail: {{should_fail|e}}
+fail_reason: {{should_fail_because|e}}
 tags: {{tags|e}}
 incdirs: {{incdirs|e}}
 top_module: {{top_module|e}}

--- a/tools/runner
+++ b/tools/runner
@@ -78,10 +78,11 @@ if args.version:
 test = os.path.abspath(os.path.join(dirs['tests'], args.test))
 
 req_test_params = [
-    "name", "tags", "description", "should_fail", "files", "incdirs",
-    "top_module", "timeout", "type"
+    "name", "tags", "description", "files", "incdirs", "top_module", "timeout",
+    "type"
 ]
 
+optional_test_params = ["should_fail", "should_fail_because"]
 test_params = {}
 
 # look for all required params
@@ -96,7 +97,8 @@ try:
             param_name = param.group(1).lower()
             param_value = param.group(2)
 
-            if param_name not in req_test_params:
+            if (param_name not in req_test_params) and (
+                    param_name not in optional_test_params):
                 logger.warning(
                     "Unsupported test param found: {} - ignoring".format(
                         param_name))
@@ -104,8 +106,9 @@ try:
 
             test_params[param_name] = param_value
 
-            if len(set(req_test_params) - set(test_params.keys())) == 0:
-                # all parameters found
+            # check all items in the req_test_params exists in the test_params.
+            if len(set(req_test_params) - set(test_params.keys())) < 0:
+                # all required parameters found
                 break
 
         else:
@@ -116,7 +119,20 @@ try:
             test_params.setdefault('timeout', "10")
             test_params.setdefault('type', 'parsing')
 
-            if len(set(req_test_params) - set(test_params.keys())) != 0:
+            # it is an error if there is a contradictory should_fail: 0 \
+            # tag and also a should_fail_because: <msg> tag
+            if ("should_fail", "0") in test_params.keys(
+            ) and "should_fail_because" in test_params.keys():
+                logger.error(
+                    "contradictory params should_fail, should_fail_because.")
+                sys.exit(1)
+            # to keep the rest of the code backward compatiple, \
+            # if should_fails not present, add the parameter
+            elif "should_fail" not in test_params.keys():
+                test_params["should_fail"] = (
+                    "0", "1")["should_fail_because" in test_params.keys()]
+
+            if len(set(req_test_params) - set(test_params.keys())) > 0:
                 missing = list(set(req_test_params) - set(test_params.keys()))
                 logger.error(
                     "Required parameters missing ({}) in {}".format(
@@ -133,7 +149,6 @@ test_params['incdirs'] = list(
         test_params['incdirs'].split()))
 
 test_params['mode'] = runner_obj.get_mode(test_params['type'].split())
-
 if test_params['mode'] is None:
     logger.info("Skipping {}/{}".format(args.runner, args.test))
     with open(out, "w") as f:

--- a/tools/runner
+++ b/tools/runner
@@ -77,15 +77,14 @@ if args.version:
 
 test = os.path.abspath(os.path.join(dirs['tests'], args.test))
 
-req_test_params = [
+supported_test_params = [
     "name", "tags", "description", "files", "incdirs", "top_module", "timeout",
-    "type"
+    "type", "should_fail", "should_fail_because"
 ]
 
-optional_test_params = ["should_fail", "should_fail_because"]
 test_params = {}
 
-# look for all required params
+# look for all supported params
 try:
     with open(test) as f:
         for l in f:
@@ -97,8 +96,7 @@ try:
             param_name = param.group(1).lower()
             param_value = param.group(2)
 
-            if (param_name not in req_test_params) and (
-                    param_name not in optional_test_params):
+            if param_name not in supported_test_params:
                 logger.warning(
                     "Unsupported test param found: {} - ignoring".format(
                         param_name))
@@ -106,9 +104,9 @@ try:
 
             test_params[param_name] = param_value
 
-            # check all items in the req_test_params exists in the test_params.
-            if len(set(req_test_params) - set(test_params.keys())) < 0:
-                # all required parameters found
+            # check all items in the supported_test_params exists in the test_params.
+            if len(set(supported_test_params) - set(test_params.keys())) == 0:
+                # all supported parameters found
                 break
 
         else:
@@ -118,22 +116,14 @@ try:
             test_params.setdefault('top_module', '')
             test_params.setdefault('timeout', "10")
             test_params.setdefault('type', 'parsing')
+            test_params.setdefault(
+                'should_fail',
+                ("0", "1")["should_fail_because" in test_params.keys()])
+            test_params.setdefault('should_fail_because', "")
 
-            # it is an error if there is a contradictory should_fail: 0 \
-            # tag and also a should_fail_because: <msg> tag
-            if ("should_fail", "0") in test_params.keys(
-            ) and "should_fail_because" in test_params.keys():
-                logger.error(
-                    "contradictory params should_fail, should_fail_because.")
-                sys.exit(1)
-            # to keep the rest of the code backward compatiple, \
-            # if should_fails not present, add the parameter
-            elif "should_fail" not in test_params.keys():
-                test_params["should_fail"] = (
-                    "0", "1")["should_fail_because" in test_params.keys()]
-
-            if len(set(req_test_params) - set(test_params.keys())) > 0:
-                missing = list(set(req_test_params) - set(test_params.keys()))
+            if len(set(supported_test_params) - set(test_params.keys())) != 0:
+                missing = list(
+                    set(supported_test_params) - set(test_params.keys()))
                 logger.error(
                     "Required parameters missing ({}) in {}".format(
                         ", ".join(missing), args.test))
@@ -141,6 +131,17 @@ try:
 except Exception as e:
     logger.error("Unable to parse test file: {}".format(str(e)))
     sys.exit(1)
+
+# if the string is not empty and should_fail is 0
+# then set it to 1 and issue a warning
+if test_params["should_fail"] == "0" and test_params["should_fail_because"]:
+    test_params["should_fail"] = "1"
+    logger.warning("contradictory params should_fail, should_fail_because.")
+# if string is empty and should_fail is 1
+elif test_params[
+        "should_fail"] == "1" and not test_params["should_fail_because"]:
+    logger.warning(
+        "should_fail tag should be replaced with should_fail_because.")
 
 test_params['files'] = test_params['files'].split()
 test_params['incdirs'] = list(

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -271,6 +271,7 @@ def collect_logs(runner_name):
             "type", "mode", "timeout", "user_time", "system_time", "ram_usage",
             "tool_success"
         ]
+        optional_test_tags = ["should_fail_because"]
         with open(t, "r") as f:
             try:
                 for l in f:
@@ -284,7 +285,10 @@ def collect_logs(runner_name):
                     param = tag.group(1).lower()
                     value = tag.group(2).strip()
 
-                    if param in test_tags:
+                    if param in optional_test_tags:
+                        optional_test_tags.remove(param)
+                        tests[t_id][param] = value
+                    elif param in test_tags:
                         test_tags.remove(param)
                         tests[t_id][param] = value
 
@@ -301,7 +305,6 @@ def collect_logs(runner_name):
                     "Skipping {} on {}: {}".format(t, runner_name, str(e)))
                 del tests[t_id]
                 continue
-
             tests[t_id]["log"] = f.read()
             tests[t_id]["fname"] = os.path.join('logs', t_id + '.html')
 

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -269,9 +269,8 @@ def collect_logs(runner_name):
             "name", "tags", "should_fail", "rc", "description", "files",
             "incdirs", "top_module", "runner", "runner_url", "time_elapsed",
             "type", "mode", "timeout", "user_time", "system_time", "ram_usage",
-            "tool_success"
+            "tool_success", "should_fail_because"
         ]
-        optional_test_tags = ["should_fail_because"]
         with open(t, "r") as f:
             try:
                 for l in f:
@@ -285,10 +284,7 @@ def collect_logs(runner_name):
                     param = tag.group(1).lower()
                     value = tag.group(2).strip()
 
-                    if param in optional_test_tags:
-                        optional_test_tags.remove(param)
-                        tests[t_id][param] = value
-                    elif param in test_tags:
+                    if param in test_tags:
                         test_tags.remove(param)
                         tests[t_id][param] = value
 


### PR DESCRIPTION
Add should_fail_because functionality solving issue #449 

specs as per the issue :
- if should_fail and should_fail_because doesn't exist, it's automatically assume should_fail: 0
- if both exist and should_fail:0, then it exits because there is a contradictory should_fail: 0 tag and also a should_fail_because: <msg> tag

* I made it backward compatible till all the tests move to the new tag, so if should_fail_because doesn't exist it'll use should_fail as before