### PR TITLE
Add separate moore parser runner

### DIFF
--- a/tools/runners/moore.py
+++ b/tools/runners/moore.py
@@ -3,9 +3,9 @@ from BaseRunner import BaseRunner
 
 
 class moore(BaseRunner):
-    def __init__(self):
+    def __init__(self, name="moore"):
         super().__init__(
-            "moore",
+            name,
             executable="moore",
             supported_features={'preprocessing', 'parsing'})
 

--- a/tools/runners/moore_parse.py
+++ b/tools/runners/moore_parse.py
@@ -1,0 +1,10 @@
+from runners.moore import moore
+
+
+class moore_parse(moore):
+    def __init__(self):
+        super().__init__("moore-parse")
+
+    def prepare_run_cb(self, tmp_dir, params):
+        self.cmd = [self.executable, '--dump-ast']
+        self.cmd += params['files']


### PR DESCRIPTION
Since the moore SV parser can be used as a standalone library, add a separate runner that just runs the moore parser, instead of also performing elaboration and code generation.