### PR TITLE
Replace :should_fail: with :should_fail_because: + reason

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ After creating a new test case it must be correctly tagged:
 
 * `name` - must be unique and should be directly related to what the test case covers.
 * `description` - should provide a short description that will be visible in the report page.
-* `should_fail` - must be used to specify whether this case is expected to fail or not.
+* `should_fail_because` - must be used if the test is expected to fail and should containt the reason of failure.
 * `files` - is a list of files used by this test case, can be omitted to use only the main file with metadata. 
 * `incdirs` - can be used to provide a list of include directories, can be omitted to use only the default ones.
 * `top_module` - optional, allows to specify which module is the top one.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ After creating a new test case it must be correctly tagged:
 
 * `name` - must be unique and should be directly related to what the test case covers.
 * `description` - should provide a short description that will be visible in the report page.
-* `should_fail_because` - must be used if the test is expected to fail and should containt the reason of failure.
+* `should_fail_because` - must be used if the test is expected to fail and should contain the reason of failure.
 * `files` - is a list of files used by this test case, can be omitted to use only the main file with metadata. 
 * `incdirs` - can be used to provide a list of include directories, can be omitted to use only the default ones.
 * `top_module` - optional, allows to specify which module is the top one.

--- a/conf/generators/templates/encapsulation-fail.json
+++ b/conf/generators/templates/encapsulation-fail.json
@@ -5,7 +5,7 @@
 		"/*",
 		":name: {0}",
 		":description: encapsulation test",
-		":should_fail: 1",
+		":should_fail_because: {1}",
 		":tags: 8.18",
 		":type: simulation",
 		"*/",
@@ -20,22 +20,22 @@
 		"    protected int b_prot = 32;",
 		"    int b = 33;",
 		"    function void fun();",
-		"        $display({1});",
+		"        $display({2});",
 		"    endfunction",
 		"endclass",
 		"b_cls b_obj;",
 		"initial begin",
 		"    b_obj = new;",
-		"    $display(b_obj.{2});",
+		"    $display(b_obj.{3});",
 		"    b_obj.fun();",
 		"end",
 		"endmodule"
 	],
 	"values": [
-		["inherited_local_from_outside", "b", "a_loc"],
-		["local_from_outside", "b", "b_loc"],
-		["inherited_prot_from_outside", "b", "a_prot"],
-		["prot_from_outside", "b", "b_prot"],
-		["inherited_local_from_inside", "a_loc", "b"]
+		["inherited_local_from_outside", "It is illegal to access inherited local variable from subclass instance.", "b", "a_loc"],
+		["local_from_outside", "It is illegal to access local variable from class instance.", "b", "b_loc"],
+		["inherited_prot_from_outside", "It is illegal to access inherited protected variable from subclass instance.", "b", "a_prot"],
+		["prot_from_outside", "It is illegal to access protected variable from class instance.", "b", "b_prot"],
+		["inherited_local_from_inside", "It is illegal to access inherited local variable inside subclass.", "a_loc", "b"]
 	]
 }

--- a/conf/generators/templates/keywords.json
+++ b/conf/generators/templates/keywords.json
@@ -5,7 +5,7 @@
 		"/*",
 		":name: keyword_{0}",
 		":description: The '{0}' keyword should be reserved",
-		":should_fail: 1",
+		":should_fail_because: The '{0}' keyword should be reserved",
 		":tags: 5.6.2",
 		"*/",
 		"module top();",

--- a/tests/chapter-10/10.3--proc-assignment--bad.sv
+++ b/tests/chapter-10/10.3--proc-assignment--bad.sv
@@ -1,7 +1,7 @@
 /*
 :name: proc_assignment__bad
 :description: continuous assignment with delay test
-:should_fail: 1
+:should_fail_because: Illegal to procedurally assign to wire, IEEE Table 10-1
 :tags: 10.3
 :type: simulation
 */

--- a/tests/chapter-11/11.3.6--assign_in_expr_inv.sv
+++ b/tests/chapter-11/11.3.6--assign_in_expr_inv.sv
@@ -1,7 +1,7 @@
 /*
 :name: assign_in_expr_inv
 :description: invalid assignment in expression test
-:should_fail: 1
+:should_fail_because: invalid assignment in expression test
 :tags: 11.3.6
 */
 module top();

--- a/tests/chapter-11/11.3.6--assign_in_expr_inv.sv
+++ b/tests/chapter-11/11.3.6--assign_in_expr_inv.sv
@@ -1,7 +1,7 @@
 /*
 :name: assign_in_expr_inv
 :description: invalid assignment in expression test
-:should_fail_because: invalid assignment in expression test
+:should_fail_because: blocking assignments within expression must be enclosed in parentheses
 :tags: 11.3.6
 */
 module top();

--- a/tests/chapter-11/11.4.14.3--unpack_stream_inv.sv
+++ b/tests/chapter-11/11.4.14.3--unpack_stream_inv.sv
@@ -1,7 +1,7 @@
 /*
 :name: unpack_stream_inv
 :description: invalid stream unpack test
-:should_fail: 1
+:should_fail_because: invalid stream unpack test
 :tags: 11.4.14.3
 :type: simulation
 */

--- a/tests/chapter-11/11.4.14.3--unpack_stream_inv.sv
+++ b/tests/chapter-11/11.4.14.3--unpack_stream_inv.sv
@@ -1,7 +1,7 @@
 /*
 :name: unpack_stream_inv
 :description: invalid stream unpack test
-:should_fail_because: invalid stream unpack test
+:should_fail_because: stream is wider than assignment target
 :tags: 11.4.14.3
 :type: simulation
 */

--- a/tests/chapter-11/11.9--tagged_union_member_access_inv.sv
+++ b/tests/chapter-11/11.9--tagged_union_member_access_inv.sv
@@ -1,7 +1,7 @@
 /*
 :name: tagged_union_member_access_inv
 :description: invalid tagged union member access test
-:should_fail_because: invalid tagged union member access test
+:should_fail_because: accessing wrong member should result in run-time error
 :tags: 11.9
 :type: simulation
 */

--- a/tests/chapter-11/11.9--tagged_union_member_access_inv.sv
+++ b/tests/chapter-11/11.9--tagged_union_member_access_inv.sv
@@ -1,7 +1,7 @@
 /*
 :name: tagged_union_member_access_inv
 :description: invalid tagged union member access test
-:should_fail: 1
+:should_fail_because: invalid tagged union member access test
 :tags: 11.9
 :type: simulation
 */

--- a/tests/chapter-13/13.4.1--function-void-return.sv
+++ b/tests/chapter-13/13.4.1--function-void-return.sv
@@ -1,7 +1,7 @@
 /*
 :name: function_void_return
 :description: void function return value test
-:should_fail: 1
+:should_fail_because: void function return value test
 :tags: 13.4.1
 :type: simulation
 */

--- a/tests/chapter-13/13.4.1--function-void-return.sv
+++ b/tests/chapter-13/13.4.1--function-void-return.sv
@@ -1,7 +1,7 @@
 /*
 :name: function_void_return
 :description: void function return value test
-:should_fail_because: void function return value test
+:should_fail_because: void function returns value
 :tags: 13.4.1
 :type: simulation
 */

--- a/tests/chapter-13/13.4.4--fork-invalid.sv
+++ b/tests/chapter-13/13.4.4--fork-invalid.sv
@@ -1,7 +1,7 @@
 /*
 :name: function_fork_invalid
 :description: function invalid fork test
-:should_fail: 1
+:should_fail_because: function invalid fork test
 :tags: 13.4.4
 :type: simulation
 */

--- a/tests/chapter-13/13.4.4--fork-invalid.sv
+++ b/tests/chapter-13/13.4.4--fork-invalid.sv
@@ -1,7 +1,7 @@
 /*
 :name: function_fork_invalid
 :description: function invalid fork test
-:should_fail_because: function invalid fork test
+:should_fail_because: only fork-join_none is permitted inside a function
 :tags: 13.4.4
 :type: simulation
 */

--- a/tests/chapter-22/22.11--pragma-invalid.sv
+++ b/tests/chapter-22/22.11--pragma-invalid.sv
@@ -1,7 +1,7 @@
 /*
 :name: 22.11--pragma-invalid
 :description: Test
-:should_fail: 1
+:should_fail_because: The pragma specification is identified by the pragma_name, which follows the `pragma directive.
 :tags: 22.11
 :type: preprocessing
 */

--- a/tests/chapter-22/22.12--line-illegal-1.sv
+++ b/tests/chapter-22/22.12--line-illegal-1.sv
@@ -1,7 +1,7 @@
 /*
 :name: 22.12--line-illegal-1
 :description: The level parameter shall be 0, 1, or 2
-:should_fail: 1
+:should_fail_because: The level parameter shall be 0, 1, or 2
 :tags: 22.12
 :type: preprocessing
 */

--- a/tests/chapter-22/22.12--line-illegal-2.sv
+++ b/tests/chapter-22/22.12--line-illegal-2.sv
@@ -1,7 +1,7 @@
 /*
 :name: 22.12--line-illegal-2
 :description: The filename parameter shall be a string literal
-:should_fail: 1
+:should_fail_because: The filename parameter shall be a string literal
 :tags: 22.12
 :type: preprocessing
 */

--- a/tests/chapter-22/22.12--line-illegal-3.sv
+++ b/tests/chapter-22/22.12--line-illegal-3.sv
@@ -1,7 +1,7 @@
 /*
 :name: 22.12--line-illegal-3
 :description: The number parameter shall be a positive integer that specifies the new line number
-:should_fail: 1
+:should_fail_because: The number parameter shall be a positive integer that specifies the new line number
 :tags: 22.12
 :type: preprocessing
 */

--- a/tests/chapter-22/22.12--line-illegal-4.sv
+++ b/tests/chapter-22/22.12--line-illegal-4.sv
@@ -1,7 +1,7 @@
 /*
 :name: 22.12--line-illegal-4
 :description: The level parameter shall be 0, 1, or 2
-:should_fail: 1
+:should_fail_because: The level parameter shall be 0, 1, or 2
 :tags: 22.12
 :type: preprocessing
 */

--- a/tests/chapter-22/22.12--line-illegal-5.sv
+++ b/tests/chapter-22/22.12--line-illegal-5.sv
@@ -1,7 +1,7 @@
 /*
 :name: 22.12--line-illegal-5
 :description: Missing filename 
-:should_fail: 1
+:should_fail_because: Missing filename 
 :tags: 22.12
 :type: preprocessing
 */

--- a/tests/chapter-22/22.3--resetall_illegal.sv
+++ b/tests/chapter-22/22.3--resetall_illegal.sv
@@ -1,7 +1,7 @@
 /*
 :name: 22.3--resetall_illegal
 :description: It shall be illegal for the `resetall directive to be specified within a design element.
-:should_fail: 1
+:should_fail_because: It shall be illegal for the `resetall directive to be specified within a design element.
 :tags: 22.3
 :type: preprocessing parsing
 */

--- a/tests/chapter-22/22.5.1--define-expansion_12.sv
+++ b/tests/chapter-22/22.5.1--define-expansion_12.sv
@@ -1,11 +1,11 @@
 /*
 :name: 22.5.1--define_expansion_12
 :description: Test
-:should_fail: 1
+:should_fail_because: If fewer actual arguments are specified than the number of formal arguments and all the remaining formal arguments have defaults, then the defaults are substituted for the additional formal arguments. It shall be an error if any of the remaining formal arguments does not have a default specified.
 :tags: 22.5.1
 :type: preprocessing
 */
 `define MACRO1(a=5,b="B",c) initial $display(a,,b,,c);
 module top ();
-`MACRO1 ( 1 )
+`MACRO1 ( 1 ) // ILLEGAL: b and c omitted, no default for c
 endmodule

--- a/tests/chapter-22/22.5.1--define-expansion_18.sv
+++ b/tests/chapter-22/22.5.1--define-expansion_18.sv
@@ -1,7 +1,7 @@
 /*
 :name: 22.5.1--define_expansion_18
 :description: Test
-:should_fail: 1
+:should_fail_because: For a macro with arguments, the parentheses are always required in the macro call, even if all the arguments have defaults. 
 :tags: 22.5.1
 :type: preprocessing
 */

--- a/tests/chapter-22/22.5.1--define-expansion_21.sv
+++ b/tests/chapter-22/22.5.1--define-expansion_21.sv
@@ -1,7 +1,7 @@
 /*
 :name: 22.5.1--define_expansion_21
 :description: Test
-:should_fail: 1
+:should_fail_because:  If more than one line is necessary to specify the text, the newline character shall be preceded by a backslash ( \ ).
 :tags: 22.5.1
 :type: preprocessing
 */

--- a/tests/chapter-22/22.5.1--define-expansion_21.sv
+++ b/tests/chapter-22/22.5.1--define-expansion_21.sv
@@ -1,7 +1,7 @@
 /*
 :name: 22.5.1--define_expansion_21
 :description: Test
-:should_fail_because:  If more than one line is necessary to specify the text, the newline character shall be preceded by a backslash ( \ ).
+:should_fail_because: text specified for macro text shall not be split across string literals
 :tags: 22.5.1
 :type: preprocessing
 */

--- a/tests/chapter-22/22.5.1--define-expansion_23.sv
+++ b/tests/chapter-22/22.5.1--define-expansion_23.sv
@@ -1,7 +1,7 @@
 /*
 :name: 22.5.1--define_expansion_23
 :description: Test
-:should_fail: 1
+:should_fail_because:  All compiler directives shall be considered predefined macro names; it shall be illegal to redefine a compiler directive as a macro name.
 :tags: 22.5.1
 :type: preprocessing
 */

--- a/tests/chapter-22/22.5.1--define-expansion_6.sv
+++ b/tests/chapter-22/22.5.1--define-expansion_6.sv
@@ -1,7 +1,7 @@
 /*
 :name: 22.5.1--define_expansion_6
 :description: Test
-:should_fail: 1
+:should_fail_because: If fewer actual arguments are specified than the number of formal arguments and all the remaining formal arguments have defaults, then the defaults are substituted for the additional formal arguments. It shall be an error if any of the remaining formal arguments does not have a default specified.
 :tags: 22.5.1
 :type: preprocessing
 */

--- a/tests/chapter-22/22.5.1--define-expansion_7.sv
+++ b/tests/chapter-22/22.5.1--define-expansion_7.sv
@@ -1,7 +1,7 @@
 /*
 :name: 22.5.1--define_expansion_7
 :description: Test
-:should_fail: 1
+:should_fail_because: To use a macro defined with arguments, the name of the text macro shall be followed by a list of actual arguments in parentheses, separated by commas.
 :tags: 22.5.1
 :type: preprocessing
 */

--- a/tests/chapter-22/22.5.1--define-expansion_8.sv
+++ b/tests/chapter-22/22.5.1--define-expansion_8.sv
@@ -1,7 +1,7 @@
 /*
 :name: 22.5.1--define_expansion_8
 :description: Test
-:should_fail: 1
+:should_fail_because: It shall be an error to specify more actual arguments than the number of formal arguments.
 :tags: 22.5.1
 :type: preprocessing
 */

--- a/tests/chapter-22/22.7--timescale-basic-3.sv
+++ b/tests/chapter-22/22.7--timescale-basic-3.sv
@@ -1,7 +1,7 @@
 /*
 :name: 22.7--timescale-basic-3
 :description: Test
-:should_fail: 1
+:should_fail_because: The integers in `timescale arguments specify an order of magnitude for the size of the value; the valid integers are 1, 10, and 100
 :tags: 22.7
 :type: simulation
 */

--- a/tests/chapter-22/22.7--timescale-basic-4.sv
+++ b/tests/chapter-22/22.7--timescale-basic-4.sv
@@ -1,8 +1,8 @@
 /*
 :name: 22.7--timescale-basic-4
 :description: Test
-:should_fail_because: `timescale precision is greater than resolution
+:should_fail_because: The time_precision argument shall be at least as precise as the time_unit argument; it cannot specify a longerunit of time than time_unit.
 :tags: 22.7
 :type: simulation
 */
-`timescale 1 ns / 1000 ps
+`timescale 1 ns / 10 ns

--- a/tests/chapter-22/22.7--timescale-basic-4.sv
+++ b/tests/chapter-22/22.7--timescale-basic-4.sv
@@ -1,7 +1,7 @@
 /*
 :name: 22.7--timescale-basic-4
 :description: Test
-:should_fail: 1
+:should_fail_because: `timescale precision is greater than resolution
 :tags: 22.7
 :type: simulation
 */

--- a/tests/chapter-22/22.9--unconnected_drive-invalid-1.sv
+++ b/tests/chapter-22/22.9--unconnected_drive-invalid-1.sv
@@ -1,7 +1,7 @@
 /*
 :name: 22.9--unconnected_drive-invalid-1
 :description: Test
-:should_fail: 1
+:should_fail_because: The directive `unconnected_drive takes one of two arguments—pull1 or pull0.
 :tags: 22.9
 :type: preprocessing
 */

--- a/tests/chapter-22/22.9--unconnected_drive-invalid-2.sv
+++ b/tests/chapter-22/22.9--unconnected_drive-invalid-2.sv
@@ -1,7 +1,7 @@
 /*
 :name: 22.9--unconnected_drive-invalid-2
-:description: Test
-:should_fail: 1
+:description: Test unconnected drive macro with argument other than pull0 and pull1
+:should_fail_because: The directive `unconnected_drive takes one of two arguments—pull1 or pull0 
 :tags: 22.9
 :type: preprocessing
 */

--- a/tests/chapter-22/22.9--unconnected_drive-invalid-3.sv
+++ b/tests/chapter-22/22.9--unconnected_drive-invalid-3.sv
@@ -1,9 +1,9 @@
 /*
 :name: 22.9--unconnected_drive-invalid-3
 :description: Test
-:should_fail: 1
+:should_fail_because: use a strength keyword with `nounconnected_drive macro
 :tags: 22.9
 :type: preprocessing
 */
-`unconnected_drive pull0
+`unconnected_drive pull0 
 `nounconnected_drive pull0

--- a/tests/chapter-5/5.10-structure-arrays-illegal.sv
+++ b/tests/chapter-5/5.10-structure-arrays-illegal.sv
@@ -1,7 +1,7 @@
 /*
 :name: structure-arrays-illegal
 :description: Structure array assignment tests
-:should_fail_because: Structure array assignment tests
+:should_fail_because: C-like assignment is illegal
 :tags: 5.10
 :type: simulation
 */

--- a/tests/chapter-5/5.10-structure-arrays-illegal.sv
+++ b/tests/chapter-5/5.10-structure-arrays-illegal.sv
@@ -1,7 +1,7 @@
 /*
 :name: structure-arrays-illegal
 :description: Structure array assignment tests
-:should_fail: 1
+:should_fail_because: Structure array assignment tests
 :tags: 5.10
 :type: simulation
 */

--- a/tests/chapter-5/5.6--wrong-identifiers.sv
+++ b/tests/chapter-5/5.6--wrong-identifiers.sv
@@ -1,7 +1,7 @@
 /*
 :name: wrong-identifiers
 :description: Identifiers that should not be accepted
-:should_fail_because: Identifiers that should not be accepted
+:should_fail_because: The first character of a simple identifier shall not be a digit or $
 :tags: 5.6
 */
 module identifiers();

--- a/tests/chapter-5/5.6--wrong-identifiers.sv
+++ b/tests/chapter-5/5.6--wrong-identifiers.sv
@@ -1,7 +1,7 @@
 /*
 :name: wrong-identifiers
 :description: Identifiers that should not be accepted
-:should_fail: 1
+:should_fail_because: Identifiers that should not be accepted
 :tags: 5.6
 */
 module identifiers();

--- a/tests/chapter-5/5.7.1--integers-signed-illegal.sv
+++ b/tests/chapter-5/5.7.1--integers-signed-illegal.sv
@@ -1,7 +1,7 @@
 /*
 :name: integers-sized-illegal
 :description: Integer literal constants
-:should_fail: 1
+:should_fail_because: Integer literal constants
 :tags: 5.7.1
 */
 module top();

--- a/tests/chapter-5/5.7.1--integers-signed-illegal.sv
+++ b/tests/chapter-5/5.7.1--integers-signed-illegal.sv
@@ -1,7 +1,7 @@
 /*
 :name: integers-sized-illegal
 :description: Integer literal constants
-:should_fail_because: Integer literal constants
+:should_fail_because: illegal negative decimal syntax, proper one is -8'd6
 :tags: 5.7.1
 */
 module top();

--- a/tests/chapter-5/5.7.1--integers-unsized-illegal.sv
+++ b/tests/chapter-5/5.7.1--integers-unsized-illegal.sv
@@ -1,7 +1,7 @@
 /*
 :name: integers-unsized-illegal
 :description: Integer literal constants
-:should_fail_because: Integer literal constants
+:should_fail_because: hexadecimal format requires 'h
 :tags: 5.7.1
 */
 module top();

--- a/tests/chapter-5/5.7.1--integers-unsized-illegal.sv
+++ b/tests/chapter-5/5.7.1--integers-unsized-illegal.sv
@@ -1,7 +1,7 @@
 /*
 :name: integers-unsized-illegal
 :description: Integer literal constants
-:should_fail: 1
+:should_fail_because: Integer literal constants
 :tags: 5.7.1
 */
 module top();

--- a/tests/chapter-5/5.7.2-real-constants-illegal.sv
+++ b/tests/chapter-5/5.7.2-real-constants-illegal.sv
@@ -1,7 +1,7 @@
 /*
 :name: real-constants-illegal
 :description: Examples of real literal constants
-:should_fail: 1
+:should_fail_because: Examples of real literal constants
 :tags: 5.7.2
 */
 module top();

--- a/tests/chapter-5/5.7.2-real-constants-illegal.sv
+++ b/tests/chapter-5/5.7.2-real-constants-illegal.sv
@@ -1,7 +1,7 @@
 /*
 :name: real-constants-illegal
 :description: Examples of real literal constants
-:should_fail_because: Examples of real literal constants
+:should_fail_because: Real literal constants must have at least one digit on each side of the decimal point
 :tags: 5.7.2
 */
 module top();

--- a/tests/chapter-6/6.12--real_bit_select.sv
+++ b/tests/chapter-6/6.12--real_bit_select.sv
@@ -1,7 +1,7 @@
 /*
 :name: real_idx
 :description: real indexing tests
-:should_fail: 1
+:should_fail_because: real indexing tests
 :tags: 6.12
 :type: simulation
 */

--- a/tests/chapter-6/6.12--real_bit_select.sv
+++ b/tests/chapter-6/6.12--real_bit_select.sv
@@ -1,7 +1,7 @@
 /*
 :name: real_idx
 :description: real indexing tests
-:should_fail_because: real indexing tests
+:should_fail_because: it is illegal to do bit select on real data type
 :tags: 6.12
 :type: simulation
 */

--- a/tests/chapter-6/6.12--real_bit_select_idx.sv
+++ b/tests/chapter-6/6.12--real_bit_select_idx.sv
@@ -1,7 +1,7 @@
 /*
 :name: real_bit_select
 :description: real bit select tests
-:should_fail: 1
+:should_fail_because: real bit select tests
 :tags: 6.12
 :type: simulation
 */

--- a/tests/chapter-6/6.12--real_bit_select_idx.sv
+++ b/tests/chapter-6/6.12--real_bit_select_idx.sv
@@ -1,7 +1,7 @@
 /*
 :name: real_bit_select
 :description: real bit select tests
-:should_fail_because: real bit select tests
+:should_fail_because: it is illegal to do bit select on real data type
 :tags: 6.12
 :type: simulation
 */

--- a/tests/chapter-6/6.12--real_edge.sv
+++ b/tests/chapter-6/6.12--real_edge.sv
@@ -1,7 +1,7 @@
 /*
 :name: real_edge
 :description: real edge event tests
-:should_fail_because: real edge event tests
+:should_fail_because: it is illegal to use edge event controls on real type
 :tags: 6.12
 :type: simulation
 */

--- a/tests/chapter-6/6.12--real_edge.sv
+++ b/tests/chapter-6/6.12--real_edge.sv
@@ -1,7 +1,7 @@
 /*
 :name: real_edge
 :description: real edge event tests
-:should_fail: 1
+:should_fail_because: real edge event tests
 :tags: 6.12
 :type: simulation
 */

--- a/tests/chapter-6/6.19--enum_value_inv.sv
+++ b/tests/chapter-6/6.19--enum_value_inv.sv
@@ -1,7 +1,7 @@
 /*
 :name: enum_value_inv
 :description: Tests that tools diagnose invalid enum value assignments
-:should_fail_because: Tests that tools diagnose invalid enum value assignments
+:should_fail_because: If the integer value expression is a sized literal constant, it shall be an error if the size is different from the enum base type, even if the value is within the representable range.
 :tags: 6.19
 */
 module top();

--- a/tests/chapter-6/6.19--enum_value_inv.sv
+++ b/tests/chapter-6/6.19--enum_value_inv.sv
@@ -1,7 +1,7 @@
 /*
 :name: enum_value_inv
 :description: Tests that tools diagnose invalid enum value assignments
-:should_fail: 1
+:should_fail_because: Tests that tools diagnose invalid enum value assignments
 :tags: 6.19
 */
 module top();

--- a/tests/chapter-6/6.19--enum_xx_inv.sv
+++ b/tests/chapter-6/6.19--enum_xx_inv.sv
@@ -1,7 +1,7 @@
 /*
 :name: enum_xx_inv
 :description: invalid enum with x tests
-:should_fail_because: invalid enum with x tests
+:should_fail_because: An enumerated name with x or z assignments assigned to an enum with no explicit data type or an explicit2-state declaration shall be a syntax error
 :tags: 6.19
 :type: simulation
 */

--- a/tests/chapter-6/6.19--enum_xx_inv.sv
+++ b/tests/chapter-6/6.19--enum_xx_inv.sv
@@ -1,7 +1,7 @@
 /*
 :name: enum_xx_inv
 :description: invalid enum with x tests
-:should_fail: 1
+:should_fail_because: invalid enum with x tests
 :tags: 6.19
 :type: simulation
 */

--- a/tests/chapter-6/6.19--enum_xx_inv_order.sv
+++ b/tests/chapter-6/6.19--enum_xx_inv_order.sv
@@ -1,7 +1,7 @@
 /*
 :name: enum_xx_inv_order
 :description: unassigned name following enum with x tests
-:should_fail: 1
+:should_fail_because: An unassigned enumerated name that follows an enum name with x or z assignments shall be a syntax error.
 :tags: 6.19
 :type: simulation
 */

--- a/tests/chapter-6/6.19.3--enum_type_checking_inv.sv
+++ b/tests/chapter-6/6.19.3--enum_type_checking_inv.sv
@@ -1,7 +1,7 @@
 /*
 :name: enum_type_checking_inv
 :description: invalid enum assignment tests
-:should_fail: 1
+:should_fail_because: invalid enum assignment tests
 :tags: 6.19.3
 :type: simulation
 */

--- a/tests/chapter-6/6.19.3--enum_type_checking_inv.sv
+++ b/tests/chapter-6/6.19.3--enum_type_checking_inv.sv
@@ -1,7 +1,7 @@
 /*
 :name: enum_type_checking_inv
 :description: invalid enum assignment tests
-:should_fail_because: invalid enum assignment tests
+:should_fail_because: enum enforces strict type checking rules
 :tags: 6.19.3
 :type: simulation
 */

--- a/tests/chapter-6/6.19.4--enum_numerical_expr_no_cast.sv
+++ b/tests/chapter-6/6.19.4--enum_numerical_expr_no_cast.sv
@@ -1,7 +1,7 @@
 /*
 :name: enum_numerical_expr_no_cast
 :description: enum numerical expression without casting
-:should_fail: 1
+:should_fail_because: enum numerical expression without casting
 :tags: 6.19.4
 :type: simulation
 */

--- a/tests/chapter-6/6.20.5--specparam_inv.sv
+++ b/tests/chapter-6/6.20.5--specparam_inv.sv
@@ -1,7 +1,7 @@
 /*
 :name: specparam_inv
 :description: specparam assignment to param should be invalid
-:should_fail: 1
+:should_fail_because: specparam assignment to param should be invalid
 :tags: 6.20.5
 :type: simulation
 */

--- a/tests/chapter-6/6.5--variable_mixed_assignments.sv
+++ b/tests/chapter-6/6.5--variable_mixed_assignments.sv
@@ -1,7 +1,7 @@
 /*
 :name: variable_mixed_assignments
 :description: Variable mixed assignments tests
-:should_fail_because: Variable mixed assignments tests
+:should_fail_because: mixing procedural and continuous assignments is illegal
 :tags: 6.5
 :type: simulation
 */

--- a/tests/chapter-6/6.5--variable_mixed_assignments.sv
+++ b/tests/chapter-6/6.5--variable_mixed_assignments.sv
@@ -1,7 +1,7 @@
 /*
 :name: variable_mixed_assignments
 :description: Variable mixed assignments tests
-:should_fail: 1
+:should_fail_because: Variable mixed assignments tests
 :tags: 6.5
 :type: simulation
 */

--- a/tests/chapter-6/6.5--variable_multiple_assignments.sv
+++ b/tests/chapter-6/6.5--variable_multiple_assignments.sv
@@ -1,7 +1,7 @@
 /*
 :name: variable_multiple_assignments
 :description: Variable multiple assignments tests
-:should_fail_because: Variable multiple assignments tests
+:should_fail_because: it shall be an error to have multiple continuous assignments
 :tags: 6.5
 :type: simulation
 */

--- a/tests/chapter-6/6.5--variable_multiple_assignments.sv
+++ b/tests/chapter-6/6.5--variable_multiple_assignments.sv
@@ -1,7 +1,7 @@
 /*
 :name: variable_multiple_assignments
 :description: Variable multiple assignments tests
-:should_fail: 1
+:should_fail_because: Variable multiple assignments tests
 :tags: 6.5
 :type: simulation
 */

--- a/tests/chapter-6/6.5--variable_redeclare.sv
+++ b/tests/chapter-6/6.5--variable_redeclare.sv
@@ -1,7 +1,7 @@
 /*
 :name: variable_redeclare
 :description: Variable redeclaration tests
-:should_fail: 1
+:should_fail_because: Variable redeclaration tests
 :tags: 6.5
 :type: simulation
 */

--- a/tests/chapter-6/6.5--variable_redeclare.sv
+++ b/tests/chapter-6/6.5--variable_redeclare.sv
@@ -1,7 +1,7 @@
 /*
 :name: variable_redeclare
 :description: Variable redeclaration tests
-:should_fail_because: Variable redeclaration tests
+:should_fail_because: Variable redeclaration
 :tags: 6.5
 :type: simulation
 */

--- a/tests/chapter-6/6.9.2--vector_vectored_inv.sv
+++ b/tests/chapter-6/6.9.2--vector_vectored_inv.sv
@@ -1,7 +1,7 @@
 /*
 :name: vector_vectored_inv
 :description: vectored vector invalid access tests
-:should_fail_because: vectored vector invalid access tests
+:should_fail_because: bit selects are not permitted on vectored vector nets
 :tags: 6.9.2
 */
 module top();

--- a/tests/chapter-6/6.9.2--vector_vectored_inv.sv
+++ b/tests/chapter-6/6.9.2--vector_vectored_inv.sv
@@ -1,7 +1,7 @@
 /*
 :name: vector_vectored_inv
 :description: vectored vector invalid access tests
-:should_fail: 1
+:should_fail_because: vectored vector invalid access tests
 :tags: 6.9.2
 */
 module top();

--- a/tests/chapter-7/arrays/packed/variable-slice-zero.sv
+++ b/tests/chapter-7/arrays/packed/variable-slice-zero.sv
@@ -1,7 +1,7 @@
 /*
 :name: operations-on-arrays-variable-slice-zero-rw
 :description: Test packed arrays operations support (Variable slice)
-:should_fail: 1
+:should_fail_becasue: slicing array with zero part width
 :tags: 7.4.3
 :type: simulation
 */

--- a/tests/chapter-7/structures/packed/default-value.sv
+++ b/tests/chapter-7/structures/packed/default-value.sv
@@ -1,7 +1,7 @@
 /*
 :name: packed-structures-default-members-value
 :description: Test packed structures default value support
-:should_fail: 1
+:should_fail_because: members of packed structures shall not be assigned individual default member values.
 :tags: 7.2.2
 :type: simulation
 */

--- a/tests/chapter-8/8.21--abstract_class_inst.sv
+++ b/tests/chapter-8/8.21--abstract_class_inst.sv
@@ -1,7 +1,7 @@
 /*
 :name: abstract_class_inst
 :description: instantiating abstract class
-:should_fail: 1
+:should_fail_because: instantiating abstract class
 :tags: 8.21
 :type: simulation
 */

--- a/tests/chapter-8/8.25.1--parametrized_class_invalid_scope_resolution.sv
+++ b/tests/chapter-8/8.25.1--parametrized_class_invalid_scope_resolution.sv
@@ -1,7 +1,7 @@
 /*
 :name: parametrized_class_invalid_scope_resolution
 :description: parametrized class invalid scope resolution
-:should_fail: 1
+:should_fail_because: parametrized class invalid scope resolution
 :tags: 8.25.1
 :type: simulation
 */

--- a/tests/chapter-8/8.26.3--type_access_implements_invalid.sv
+++ b/tests/chapter-8/8.26.3--type_access_implements_invalid.sv
@@ -1,7 +1,7 @@
 /*
 :name: type_access_implements_invalid
 :description: access types from implemented class
-:should_fail: 1
+:should_fail_because: access types from implemented class
 :tags: 8.26.3
 :type: simulation
 */

--- a/tests/chapter-8/8.26.3--type_access_implements_invalid.sv
+++ b/tests/chapter-8/8.26.3--type_access_implements_invalid.sv
@@ -1,7 +1,7 @@
 /*
 :name: type_access_implements_invalid
 :description: access types from implemented class
-:should_fail_because: access types from implemented class
+:should_fail_because: typedefs are not inherited by implements operator
 :tags: 8.26.3
 :type: simulation
 */

--- a/tests/chapter-8/8.26.4--illegal_forward_def_implements.sv
+++ b/tests/chapter-8/8.26.4--illegal_forward_def_implements.sv
@@ -1,7 +1,7 @@
 /*
 :name: illegal_forward_def_implements
 :description: implementing forward typedef for an interface class should fail
-:should_fail: 1
+:should_fail_because: implementing forward typedef for an interface class should fail
 :tags: 8.26.4
 :type: simulation
 */

--- a/tests/chapter-8/8.26.4--illegal_implements_parameter.sv
+++ b/tests/chapter-8/8.26.4--illegal_implements_parameter.sv
@@ -1,7 +1,7 @@
 /*
 :name: illegal_implements_parameter
 :description: implementing parameter that resolves to an interface class is not allowed
-:should_fail: 1
+:should_fail_because: implementing parameter that resolves to an interface class is not allowed
 :tags: 8.26.4
 :type: simulation
 */

--- a/tests/chapter-8/8.26.5--invalid_interface_instantiation.sv
+++ b/tests/chapter-8/8.26.5--invalid_interface_instantiation.sv
@@ -1,7 +1,7 @@
 /*
 :name: interface_instantiation
 :description: instantiating an interface class
-:should_fail: 1
+:should_fail_because: instantiating an interface class
 :tags: 8.26.5
 :type: simulation
 */

--- a/tests/chapter-8/8.26.6.1--name_conflict_unresolved.sv
+++ b/tests/chapter-8/8.26.6.1--name_conflict_unresolved.sv
@@ -1,7 +1,7 @@
 /*
 :name: name_conflict_unresolved
 :description: unresolved interface class method name conflict
-:should_fail: 1
+:should_fail_because: unresolved interface class method name conflict
 :tags: 8.26.6.1
 :type: simulation
 */

--- a/tests/chapter-8/8.26.6.2--parameter_type_conflict_unresolved.sv
+++ b/tests/chapter-8/8.26.6.2--parameter_type_conflict_unresolved.sv
@@ -1,7 +1,7 @@
 /*
 :name: parameter_type_conflict_unresolved
 :description: superclass type declaration conflicts must be resolved in subclass
-:should_fail: 1
+:should_fail_because: superclass type declaration conflicts must be resolved in subclass
 :tags: 8.26.6.2
 :type: simulation
 */

--- a/tests/chapter-8/8.26.6.3--diamond_relationship_parametrized.sv
+++ b/tests/chapter-8/8.26.6.3--diamond_relationship_parametrized.sv
@@ -1,7 +1,7 @@
 /*
 :name: diamond_relationship_parametrized
 :description: different specializations of an interface class are treated as unique interface class types
-:should_fail: 1
+:should_fail_because: different specializations of an interface class are treated as unique interface class types
 :tags: 8.26.6.3
 :type: simulation
 */

--- a/tests/chapter-9/9.3.3--fork_return.sv
+++ b/tests/chapter-9/9.3.3--fork_return.sv
@@ -1,7 +1,7 @@
 /*
 :name: fork_return
 :description: illegal return from fork
-:should_fail: 1
+:should_fail_because: illegal return from fork
 :tags: 9.3.3
 :type: simulation
 */

--- a/tests/generic/typedef/typedef_test_25__bad.sv
+++ b/tests/generic/typedef/typedef_test_25__bad.sv
@@ -1,12 +1,13 @@
 /*
 :name: typedef_test_25__bad
 :description: Test
-:should_fail: 1
+:should_fail_because: Using undefined parameters
 :tags: 6.18
 :type: simulation
 */
 
 // A/D/E/M are not defined, so bad test.
+//6.18 is for user-defined types, this test doesnot contain a user defined type? 
 
 typedef struct packed {
   reg  [A-1:0] addr;

--- a/tests/generic/typedef/typedef_test_25__bad.sv
+++ b/tests/generic/typedef/typedef_test_25__bad.sv
@@ -7,7 +7,6 @@
 */
 
 // A/D/E/M are not defined, so bad test.
-//6.18 is for user-defined types, this test doesnot contain a user defined type? 
 
 typedef struct packed {
   reg  [A-1:0] addr;

--- a/tests/generic/typedef/typedef_test_28__bad.sv
+++ b/tests/generic/typedef/typedef_test_28__bad.sv
@@ -1,7 +1,7 @@
 /*
 :name: typedef_test_28
 :description: Test
-:should_fail: 1
+:should_fail_because: missing forward typedef declaration, type_identifier does not resolve to a data type.
 :tags: 6.18
 */
 

--- a/tests/generic/typedef/typedef_test_8__bad.sv
+++ b/tests/generic/typedef/typedef_test_8__bad.sv
@@ -1,7 +1,7 @@
 /*
 :name: typedef_test_8__bad
 :description: Test
-:should_fail: 1
+:should_fail_because: defining a type using an undefined type
 :tags: 6.18
 :type: simulation
 */

--- a/tests/sanity.sv
+++ b/tests/sanity.sv
@@ -1,7 +1,7 @@
 /*
 :name: sanity
 :description: A simple module that should fail during parsing
-:should_fail: 1
+:should_fail_because: syntax error, fails during parsing
 :tags: sanity
 */
 module sanity_tb (


### PR DESCRIPTION
Replace :should_fail: with :should_fail_because: with the reason solving issue #688 
so I created a script to iterate over all the tests with :should_fail: 1 and print me the description and the code to tell if the description can go in failing reason's, it would go automatically, otherwise i edit the rest manually. 

* the `conf/generators/templates` files were modified manually.

the code 
```
#!/bin/bash
 dir="tests"
 [[ -z $dir ]] && exit
 for file in $(find $dir -name "*.sv" -type f)
 do
     if [[ -n $(grep "should_fail: 1" $file) ]]
     then
         description=$(cat $file | grep -o ":description:.*" | cut -f 3 -d ':')
         echo "Description: $description"
         cat $file | awk '/module/,0'
         echo -n "good reason? "
         read goodReason
         if [[ $goodReason ==  1 ]]
         then
             sed -i "s/:should_fail: 1/:should_fail_because:$description/g" $file
             echo $file >> DoneFiles.txt
         else
             echo $file >> needManualReason.txt
         fi
 
     fi  
 done
```
so the auto modified files are: 
> tests/chapter-11/11.3.6--assign_in_expr_inv.sv
> tests/chapter-11/11.4.14.3--unpack_stream_inv.sv
> tests/chapter-11/11.9--tagged_union_member_access_inv.sv
> tests/chapter-22/22.12--line-illegal-1.sv
> tests/chapter-22/22.12--line-illegal-5.sv
> tests/chapter-22/22.12--line-illegal-2.sv
> tests/chapter-22/22.12--line-illegal-3.sv
> tests/chapter-22/22.3--resetall_illegal.sv
> tests/chapter-22/22.12--line-illegal-4.sv
> tests/chapter-9/9.3.3--fork_return.sv
> tests/chapter-8/8.25.1--parametrized_class_invalid_scope_resolution.sv
> tests/chapter-8/8.26.4--illegal_implements_parameter.sv
> tests/chapter-8/8.26.4--illegal_forward_def_implements.sv
> tests/chapter-8/8.26.6.1--name_conflict_unresolved.sv
> tests/chapter-8/8.26.3--type_access_implements_invalid.sv
> tests/chapter-8/8.26.6.2--parameter_type_conflict_unresolved.sv
> tests/chapter-8/8.26.5--invalid_interface_instantiation.sv
> tests/chapter-8/8.26.6.3--diamond_relationship_parametrized.sv
> tests/chapter-8/8.21--abstract_class_inst.sv
> tests/chapter-6/6.12--real_bit_select.sv
> tests/chapter-6/6.5--variable_mixed_assignments.sv
> tests/chapter-6/6.20.5--specparam_inv.sv
> tests/chapter-6/6.19--enum_value_inv.sv
> tests/chapter-6/6.12--real_edge.sv
> tests/chapter-6/6.5--variable_multiple_assignments.sv
> tests/chapter-6/6.19.3--enum_type_checking_inv.sv
> tests/chapter-6/6.19.4--enum_numerical_expr_no_cast.sv
> tests/chapter-6/6.9.2--vector_vectored_inv.sv
> tests/chapter-6/6.19--enum_xx_inv.sv
> tests/chapter-6/6.12--real_bit_select_idx.sv
> tests/chapter-6/6.5--variable_redeclare.sv
> tests/chapter-5/5.6--wrong-identifiers.sv
> tests/chapter-5/5.7.1--integers-signed-illegal.sv
> tests/chapter-5/5.10-structure-arrays-illegal.sv
> tests/chapter-5/5.7.2-real-constants-illegal.sv
> tests/chapter-5/5.7.1--integers-unsized-illegal.sv
> tests/chapter-13/13.4.1--function-void-return.sv
> tests/chapter-13/13.4.4--fork-invalid.sv
> tests/chapter-6/6.19--enum_xx_inv_order.sv

and the manually modified files:
> tests/chapter-7/arrays/packed/variable-slice-zero.sv
> tests/chapter-7/structures/packed/default-value.sv
> tests/generic/typedef/typedef_test_8__bad.sv
> tests/generic/typedef/typedef_test_25__bad.sv
> tests/generic/typedef/typedef_test_28__bad.sv
> tests/chapter-22/22.7--timescale-basic-4.sv
> tests/chapter-22/22.5.1--define-expansion_23.sv
> tests/chapter-22/22.9--unconnected_drive-invalid-2.sv
> tests/chapter-22/22.5.1--define-expansion_21.sv
> tests/chapter-22/22.5.1--define-expansion_8.sv
> tests/chapter-22/22.5.1--define-expansion_18.sv
> tests/chapter-22/22.9--unconnected_drive-invalid-3.sv
> tests/chapter-22/22.11--pragma-invalid.sv
> tests/chapter-22/22.5.1--define-expansion_6.sv
> tests/chapter-22/22.5.1--define-expansion_12.sv
> tests/chapter-22/22.7--timescale-basic-3.sv
> tests/chapter-22/22.5.1--define-expansion_7.sv
> tests/chapter-22/22.9--unconnected_drive-invalid-1.sv
> tests/chapter-10/10.3--proc-assignment--bad.sv
> tests/chapter-6/6.19--enum_xx_inv_order.sv
