### PR TITLE
Fix Verilator version report

### DIFF
--- a/tools/runners/Verilator.py
+++ b/tools/runners/Verilator.py
@@ -10,10 +10,6 @@ class Verilator(BaseRunner):
 
         self.url = "https://verilator.org"
 
-    def get_version_cmd(self):
-        # Scripts like Verilator require calling through SHELL
-        return [os.getenv("SHELL"), self.executable, "--version"]
-
     def prepare_run_cb(self, tmp_dir, params):
         mode = params['mode']
         conf = os.environ['CONF_DIR']


### PR DESCRIPTION
The Verilator version isn't in the report header, this should fix this since Version 4.026 fixed the problem with shebang that originally required this code.
