### PR TITLE
moore: Use --syntax flag for parsing

### DIFF
--- a/tools/runners/moore_parse.py
+++ b/tools/runners/moore_parse.py
@@ -6,5 +6,5 @@ class moore_parse(moore):
         super().__init__("moore-parse")
 
     def prepare_run_cb(self, tmp_dir, params):
-        self.cmd = [self.executable, '--dump-ast']
+        self.cmd = [self.executable, '--syntax']
         self.cmd += params['files']


### PR DESCRIPTION
Rather than emitting the entire parsed AST via `--dump-ast`, use the `--syntax` flag in the parse-only test of moore.