### PR TITLE
Queue test fixes.

### DIFF
--- a/tests/chapter-7/queues/persistence.sv
+++ b/tests/chapter-7/queues/persistence.sv
@@ -16,7 +16,9 @@ task automatic fun(ref int e);
 endtask
 
 initial begin
-	q = { 1, 2, 3 };
+	q.push_back(1);
+	q.push_back(2);
+	q.push_back(3);
 	$display(":assert: ((%d == 1) and (%d == 2) and (%d == 3))",
 		q[0], q[1], q[2]);
 	fun(q[1]);
@@ -25,7 +27,7 @@ end
 initial begin
 	#50
 	$display(":assert: (%d == 2)", q[1]);
-	q = {};
+	q.delete();
 	#100;
 	$display(":assert: (%d == 0)", q.size);
 end

--- a/tests/chapter-7/queues/pop_back_assing.sv
+++ b/tests/chapter-7/queues/pop_back_assing.sv
@@ -11,10 +11,10 @@ int r;
 
 initial begin
 	q = { 2, 3, 4 };
-	r = q[$-1];
+	r = q[$];
 	q = q[0:$-1]; // void'(q.pop_back()) or q.delete(q.size-1)
 	$display(":assert: (%d == 2)", q.size);
-	$display(":assert: (%d == 3)", r);
+	$display(":assert: (%d == 4)", r);
 end
 
 endmodule

--- a/tests/chapter-7/queues/pop_back_assing.sv
+++ b/tests/chapter-7/queues/pop_back_assing.sv
@@ -14,7 +14,7 @@ initial begin
 	r = q[$-1];
 	q = q[0:$-1]; // void'(q.pop_back()) or q.delete(q.size-1)
 	$display(":assert: (%d == 2)", q.size);
-	$display(":assert: (%d == 4)", r);
+	$display(":assert: (%d == 3)", r);
 end
 
 endmodule


### PR DESCRIPTION
* tests/chapter-7/queues/persistence.sv - use methods as better supported
  (Other tests check the old syntax so no new hole)
* tests/chapter-7/queues/pop_back_assing.sv - fix incorrect value
