### PR TITLE
Fix chapter-6/6.20.2.1--parameter_unbounded.sv array ordering.

### DIFF
--- a/tests/chapter-6/6.20.2.1--parameter_unbounded.sv
+++ b/tests/chapter-6/6.20.2.1--parameter_unbounded.sv
@@ -8,5 +8,5 @@ module top();
 	wire clk = 0;
 	wire [31:0] a;
 
-	always @(posedge clk) a[0:p] = 23;
+	always @(posedge clk) a[p:0] = 23;
 endmodule


### PR DESCRIPTION
Fixes backward array order. Thanks.

