### PR TITLE
Fix some class_tests to be legal code.

### DIFF
--- a/tests/generic/class/class_test_55.sv
+++ b/tests/generic/class/class_test_55.sv
@@ -3,6 +3,9 @@
 :description: Test
 :tags: 6.15 8.3
 */
+class Packet;
+endclass
+
 class Driver;
   Packet pNP [*];
   Packet pNP1 [* ];

--- a/tests/generic/class/class_test_56.sv
+++ b/tests/generic/class/class_test_56.sv
@@ -3,6 +3,8 @@
 :description: Test
 :tags: 6.15 8.3
 */
+typedef int data_type_or_module_type;
+
 class Driver;
   data_type_or_module_type foo1;
   data_type_or_module_type foo2 = 1'b1;

--- a/tests/generic/class/class_test_57.sv
+++ b/tests/generic/class/class_test_57.sv
@@ -3,6 +3,8 @@
 :description: Test
 :tags: 6.15 8.3
 */
+typedef int data_type_or_module_type;
+
 class fields_with_modifiers;
   const data_type_or_module_type foo1 = 4'hf;
   static data_type_or_module_type foo3, foo4;

--- a/tests/generic/class/class_test_58.sv
+++ b/tests/generic/class/class_test_58.sv
@@ -3,6 +3,8 @@
 :description: Test
 :tags: 6.15 8.3
 */
+typedef int data_type_or_module_type;
+
 class fields_with_modifiers;
   const static data_type_or_module_type foo1 = 4'hf;
   static const data_type_or_module_type foo3, foo4;

--- a/tests/generic/class/class_test_6.sv
+++ b/tests/generic/class/class_test_6.sv
@@ -3,4 +3,5 @@
 :description: Test
 :tags: 6.15 8.3
 */
+class Bar; endclass
 class Foo extends Bar; endclass


### PR DESCRIPTION
This fixes some of the class_tests to be legal.  More work is needed on other tests later - parameters, packages and classes all need to be declared before use.
