### PR TITLE
Allow unconnected drive errors detected in simulation.

### DIFF
--- a/tests/chapter-22/22.9--unconnected_drive-invalid-1.sv
+++ b/tests/chapter-22/22.9--unconnected_drive-invalid-1.sv
@@ -1,9 +1,9 @@
 /*
 :name: 22.9--unconnected_drive-invalid-1
 :description: Test
-:should_fail_because: The directive `unconnected_drive takes one of two arguments—pull1 or pull0.
+:should_fail_because: The directive `unconnected_drive takes one of two arguments - pull1 or pull0.
 :tags: 22.9
-:type: preprocessing
+:type: simulation
 */
 `unconnected_drive
 `nounconnected_drive

--- a/tests/chapter-22/22.9--unconnected_drive-invalid-2.sv
+++ b/tests/chapter-22/22.9--unconnected_drive-invalid-2.sv
@@ -1,9 +1,9 @@
 /*
 :name: 22.9--unconnected_drive-invalid-2
 :description: Test unconnected drive macro with argument other than pull0 and pull1
-:should_fail_because: The directive `unconnected_drive takes one of two arguments—pull1 or pull0 
+:should_fail_because: The directive `unconnected_drive takes one of two arguments - pull1 or pull0 
 :tags: 22.9
-:type: preprocessing
+:type: simulation
 */
 `unconnected_drive pull2
 `nounconnected_drive

--- a/tests/chapter-22/22.9--unconnected_drive-invalid-3.sv
+++ b/tests/chapter-22/22.9--unconnected_drive-invalid-3.sv
@@ -3,7 +3,7 @@
 :description: Test
 :should_fail_because: use a strength keyword with `nounconnected_drive macro
 :tags: 22.9
-:type: preprocessing
+:type: simulation
 */
 `unconnected_drive pull0 
 `nounconnected_drive pull0


### PR DESCRIPTION
It's questionable where (if at all) these illegal tests would be implemented, but Verilator selected to implement them post-simulation.  I don't see any other tool that would now fail because of changing this, so I'd like Verilator to be able to get it's "green box", thanks.
