### PR TITLE
Test iverlog in parsing mode only

### DIFF
--- a/tools/runners/Icarus.py
+++ b/tools/runners/Icarus.py
@@ -4,28 +4,16 @@ import os
 
 class Icarus(BaseRunner):
     def __init__(self):
-        super().__init__("icarus", "iverilog")
+        super().__init__("icarus", "iverilog", {"parsing"})
 
         self.url = "http://iverilog.icarus.com/"
 
     def prepare_run_cb(self, tmp_dir, params):
-        mode = params['mode']
-
-        scr = os.path.join(tmp_dir, 'scr.sh')
         ofile = 'iverilog.out'
 
-        with open(scr, 'w') as f:
-            f.write('{} $@\n'.format(self.executable))
-            if mode == 'simulation':
-                f.write('vvp {}'.format(ofile))
+        self.cmd = [self.executable, "-g2012"]
 
-        self.cmd = ['sh', 'scr.sh', '-g2012']
-
-        if mode == 'preprocessing':
-            self.cmd += ['-E']
-
-        if mode == 'simulation' or mode == 'parsing':
-            self.cmd += ['-i', '-o ' + ofile]
+        self.cmd += ["-o", ofile]
 
         if params['top_module'] != '':
             self.cmd.append('-s ' + params['top_module'])


### PR DESCRIPTION
Fixes #732

It seems that Icarus was never properly tested when simulation testing was added. It changed the invoked binary a different one (iverilog -> vpp) but kept the old switches.

This PRs makes iverilog only be tested as a parser to be more fair to it. I will open a new issue to add proper simulation testing for it shortly.