### PR TITLE
Add an option to disable test timeouts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ export TESTS_DIR
 export RUNNERS_DIR
 export GENERATORS_DIR
 
+ifneq ($(DISABLE_TEST_TIMEOUTS),)
+export DISABLE_TEST_TIMEOUTS
+endif
+
 include tools/runners.mk
 
 .PHONY: clean init info tests generate-tests report

--- a/tools/BaseRunner.py
+++ b/tools/BaseRunner.py
@@ -3,6 +3,7 @@ import resource
 import shutil
 import signal
 import subprocess
+import os
 import re
 
 
@@ -107,8 +108,12 @@ class BaseRunner:
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT)
 
+        timeout = int(params['timeout'])
+        if 'DISABLE_TEST_TIMEOUTS' in os.environ:
+            timeout = None
+
         try:
-            log, _ = proc.communicate(timeout=int(params['timeout']))
+            log, _ = proc.communicate(timeout=timeout)
             returncode = proc.returncode
         except subprocess.TimeoutExpired:
             kill_child_processes(proc.pid)


### PR DESCRIPTION
Thanks to this we can easily disable test timeouts with:
```
 $ DISABLE_TEST_TIMEOUTS=1 make
```
This is useful for development.