### PR TITLE
Allow out of tree runners

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ RUNNER_PARAM := --quiet
 endif
 
 $(OUT_DIR)/logs/$(1)/$(2).log: $(TESTS_DIR)/$(2) | $(1)-cg
-	$$(RUNNER) --runner $(1) --test $(2) --out $(OUT_DIR)/logs/$(1)/$(2).log $(RUNNER_PARAM)
+	RUNNERS_DIR=$(RUNNERS_DIR) $$(RUNNER) --runner $(1) --test $(2) --out $(OUT_DIR)/logs/$(1)/$(2).log $(RUNNER_PARAM)
 
 tests: $(OUT_DIR)/logs/$(1)/$(2).log
 
@@ -95,7 +95,7 @@ endef
 RUNNERS_FOUND := $(wildcard $(RUNNERS_DIR)/*.py)
 RUNNERS_FOUND := $(RUNNERS_FOUND:$(RUNNERS_DIR)/%=%)
 RUNNERS_FOUND := $(basename $(RUNNERS_FOUND))
-RUNNERS := $(shell OUT_DIR=$(OUT_DIR) ./tools/check-runners $(RUNNERS_FOUND))
+RUNNERS := $(shell OUT_DIR=$(OUT_DIR) RUNNERS_DIR=$(RUNNERS_DIR) ./tools/check-runners $(RUNNERS_FOUND))
 TESTS := $(shell find $(TESTS_DIR) -type f -iname *.sv)
 TESTS := $(TESTS:$(TESTS_DIR)/%=%)
 GENERATORS := $(wildcard $(GENERATORS_DIR)/*)

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 all: report
 
-OUT_DIR=./out/
-CONF_DIR=./conf
-TESTS_DIR=./tests
-RUNNERS_DIR=./tools/runners
-THIRD_PARTY_DIR=./third_party
-GENERATORS_DIR=./generators
+OUT_DIR ?= ./out/
+CONF_DIR ?= ./conf
+TESTS_DIR ?= ./tests
+RUNNERS_DIR ?= ./tools/runners
+THIRD_PARTY_DIR ?= ./third_party
+GENERATORS_DIR ?= ./generators
 
 USE_CGROUP := ${USE_CGROUP}
 

--- a/tools/check-runners
+++ b/tools/check-runners
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import os
+import sys
 import argparse
 import logging
 
@@ -17,9 +18,12 @@ runner_obj = None
 
 runners_ok = []
 
+if 'RUNNERS_DIR' in os.environ:
+    sys.path.insert(1, os.path.abspath(os.environ['RUNNERS_DIR']))
+
 for runner in args.runners:
     try:
-        module = import_module('runners.' + runner)
+        module = import_module(runner)
         runner_cls = getattr(module, runner)
         runner_obj = runner_cls()
     except Exception:

--- a/tools/runner
+++ b/tools/runner
@@ -42,8 +42,11 @@ logger.addHandler(ch)
 
 runner_obj = None
 
+if 'RUNNERS_DIR' in os.environ:
+    sys.path.insert(1, os.path.abspath(os.environ['RUNNERS_DIR']))
+
 try:
-    module = import_module('runners.' + args.runner)
+    module = import_module(args.runner)
     runner_cls = getattr(module, args.runner)
     runner_obj = runner_cls()
 except Exception as e:


### PR DESCRIPTION
Thanks to these changes we can use out-of-tree runners like this:
```
RUNNERS_DIR=/my/custom/runners/ make
```

It was always the intention to be able to do this but somewhere along the way we've lost that possibility. This PR just restores this.
