### PR TITLE
tools/runner: add library files before test files

### DIFF
--- a/tools/runner
+++ b/tools/runner
@@ -173,14 +173,14 @@ if test_params['mode'] is None:
 
 for key in libs.keys():
     if key in test_params['tags']:
-        test_params['files'] += [
+        test_params['files'] = [
             os.path.abspath(os.path.join(dirs['third_party'], p))
             for p in libs[key]['files']
-        ]
-        test_params['incdirs'] += [
+        ] + test_params['files']
+        test_params['incdirs'] = [
             os.path.abspath(os.path.join(dirs['third_party'], p))
             for p in libs[key]['incdirs']
-        ]
+        ] + test_params['incdirs']
 
 try:
     tmp_dir = tempfile.mkdtemp()


### PR DESCRIPTION
This PR modifies `tools/runner` to always add library files/incdirs before the ones defined by the test itself.

This should help with #853 