### PR TITLE
Fix runners logs decoding

### DIFF
--- a/tools/BaseRunner.py
+++ b/tools/BaseRunner.py
@@ -133,7 +133,7 @@ class BaseRunner:
         invocation_log = " ".join(self.cmd) + "\n"
 
         return (
-            invocation_log + self.transform_log(log.decode('utf-8')),
+            invocation_log + self.transform_log(log.decode('utf-8', 'ignore')),
             returncode)
 
     def is_success_returncode(self, rc, params):


### PR DESCRIPTION
Some runners seem to throw non utf-8 characters in their log for some
specific tests. Ignore the invalid characters to allow the test suite to
continue.