### PR TITLE
Add simulation tests for delay statements

### DIFF
--- a/tests/chapter-9/9.4.1--delay_control-sim.sv
+++ b/tests/chapter-9/9.4.1--delay_control-sim.sv
@@ -1,0 +1,23 @@
+/*
+:name: delay_control_sim
+:description: delay control simulation
+:tags: 9.4.1
+:type: simulation
+*/
+module top();
+
+   initial begin
+      $display(":assert: (0 == %d)", $time);
+
+      #10;
+      $display(":assert: (10 == %d)", $time);
+
+      #10;
+      $display(":assert: (20 == %d)", $time);
+
+      #10;
+      $display(":assert: (30 == %d)", $time);
+
+      $finish;
+   end
+endmodule

--- a/tests/chapter-9/9.4.1--delay_control-two-blocks-sim.sv
+++ b/tests/chapter-9/9.4.1--delay_control-two-blocks-sim.sv
@@ -1,0 +1,30 @@
+/*
+:name: delay_control_two_blocks_sim
+:description: delay control simulation with two blocks
+:tags: 9.4.1
+:type: simulation
+*/
+module top();
+
+   initial begin
+      $display(":assert: (0 == %d)", $time);
+
+      #10;
+      $display(":assert: (10 == %d)", $time);
+
+      #10;
+      $display(":assert: (20 == %d)", $time);
+
+      #10;
+      $display(":assert: (30 == %d)", $time);
+
+      $finish;
+   end
+
+   initial begin
+      #5;
+      #10;
+      #10;
+   end
+endmodule
+


### PR DESCRIPTION
Just test whether the time passed is right. Adding two tests as this is something that is known not to fully work in current verilator dev branch.