### PR TITLE
Allow for more timeout for Ariane and Earlgray.

### DIFF
--- a/generators/ariane
+++ b/generators/ariane
@@ -10,7 +10,7 @@ templ = """/*
 :incdirs: {1}
 :tags: ariane
 :top_module: ariane_testharness
-:timeout: 180
+:timeout: 360
 */
 """
 

--- a/generators/earlgrey
+++ b/generators/earlgrey
@@ -12,7 +12,7 @@ templ = """/*
 :incdirs: {1}
 :tags: earlgrey uvm
 :defines: {2}
-:timeout: 180
+:timeout: 360
 :top_module: top_earlgrey_nexysvideo
 */
 """


### PR DESCRIPTION
On the CI machines, it is a hit-and-miss if they finish with Surelog

Signed-off-by: Henner Zeller <h.zeller@acm.org>