### PR TITLE
uhdm-verilator: remove -Wpedantic flag

### DIFF
--- a/tools/runners/UhdmVerilator.py
+++ b/tools/runners/UhdmVerilator.py
@@ -43,10 +43,7 @@ class UhdmVerilator(BaseRunner):
         self.cmd += ['--uhdm-ast -cc slpp_all/surelog.uhdm']
 
         # Flags for compliance testing:
-        self.cmd += [
-            '-Wno-fatal', '-Wno-UNOPTFLAT', '-Wno-BLKANDNBLK', '-Wpedantic',
-            '-Wno-context'
-        ]
+        self.cmd += ['-Wno-fatal', '-Wno-UNOPTFLAT', '-Wno-BLKANDNBLK']
 
         top = self.get_top_module_or_guess(params)
 


### PR DESCRIPTION
It is not available in uhdm-verilator (multiple tests fail because of
this flag).

Signed-off-by: Tomasz Gorochowik <tgorochowik@antmicro.com>