### PR TITLE
Migrate all remaining "should_fail" statements to "should_fail_because"

### DIFF
--- a/conf/generators/meta-path/basejump.json
+++ b/conf/generators/meta-path/basejump.json
@@ -1,7 +1,6 @@
 {
 	"name": "BaseJumpSTL",
 	"project": "basejump",
-	"should_fail": "0",
 	"paths": [
 		["cores", "basejump_stl", "*"]
 	],

--- a/conf/generators/meta-path/hdlconvertor.json
+++ b/conf/generators/meta-path/hdlconvertor.json
@@ -1,7 +1,6 @@
 {
 	"name": "hdlconvertor",
 	"project": "hdlconv",
-	"should_fail": "0",
 	"paths": [
 		["tests", "hdlconvertor", "tests", "sv_test", "*"],
 		["tests", "hdlconvertor", "tests", "verilog"]

--- a/conf/generators/meta-path/utd-systemverilog.json
+++ b/conf/generators/meta-path/utd-systemverilog.json
@@ -1,7 +1,6 @@
 {
 	"name": "utd-sv",
 	"project": "utd-sv",
-	"should_fail": "0",
 	"paths": [
 		["tests", "utd-sv"]
 	],

--- a/conf/generators/meta-path/yosys-asicworld.json
+++ b/conf/generators/meta-path/yosys-asicworld.json
@@ -1,7 +1,6 @@
 {
 	"name": "asicworld",
 	"project": "yosys",
-	"should_fail": "0",
 	"paths": [
 		["tools", "yosys", "tests", "asicworld"]
 	],

--- a/conf/generators/meta-path/yosys-errors.json
+++ b/conf/generators/meta-path/yosys-errors.json
@@ -1,7 +1,7 @@
 {
 	"name": "errors",
 	"project": "yosys",
-	"should_fail": "1",
+	"should_fail_because": "this test imported from yosys repository contains intentional syntax error",
 	"paths": [
 		["tools", "yosys", "tests", "errors"]
 	],

--- a/conf/generators/meta-path/yosys-memories.json
+++ b/conf/generators/meta-path/yosys-memories.json
@@ -1,7 +1,6 @@
 {
 	"name": "memories",
 	"project": "yosys",
-	"should_fail": "0",
 	"paths": [
 		["tools", "yosys", "tests", "memories"]
 	],

--- a/conf/generators/meta-path/yosys-simple.json
+++ b/conf/generators/meta-path/yosys-simple.json
@@ -1,7 +1,6 @@
 {
 	"name": "simple",
 	"project": "yosys",
-	"should_fail": "0",
 	"paths": [
 		["tools", "yosys", "tests", "simple"]
 	],

--- a/conf/generators/meta-path/yosys-sva.json
+++ b/conf/generators/meta-path/yosys-sva.json
@@ -1,7 +1,6 @@
 {
 	"name": "sva",
 	"project": "yosys",
-	"should_fail": "0",
 	"paths": [
 		["tools", "yosys", "tests", "sva"]
 	],

--- a/conf/generators/meta-path/yosys-svinterfaces.json
+++ b/conf/generators/meta-path/yosys-svinterfaces.json
@@ -1,7 +1,6 @@
 {
 	"name": "svinterfaces",
 	"project": "yosys",
-	"should_fail": "0",
 	"paths": [
 		["tools", "yosys", "tests", "svinterfaces"]
 	],

--- a/conf/report/log-template.html
+++ b/conf/report/log-template.html
@@ -10,11 +10,7 @@
 <pre class="{{status}}">
 description: {{description|e}}
 rc: {{rc|e}} (means success: {{tool_success|e}})
-{% if should_fail_because|length %}
 should_fail_because: {{should_fail_because|e}}
-{% else %}
-should_fail: {{should_fail|e}}
-{% endif %}
 tags: {{tags|e}}
 incdirs: {{incdirs|e}}
 top_module: {{top_module|e}}

--- a/generators/ivtest
+++ b/generators/ivtest
@@ -10,8 +10,8 @@ templ = """/*
 :description: Test imported from ivtest
 :files: {1}
 :incdirs: {4}
-:should_fail: {2}
 :tags: ivtest
+{2}
 {3}
 {5}
 */
@@ -207,7 +207,7 @@ for l in ivtest_lists:
 
             name = line[0]
             path = os.path.join(ivtest_dir, line[2], line[0] + '.v')
-            should_fail = 0
+            should_fail_because = ''
 
             # sanitize name
             name = re.sub(r'\W', '', name)
@@ -218,7 +218,7 @@ for l in ivtest_lists:
             type_ = ''
             for t in type_should_fail:
                 if re.match(t, line[1]):
-                    should_fail = 1
+                    should_fail_because = ':should_fail_because: this test was imported from ivtest and is designed to fail'
                     type_ = ':type: simulation'
 
             timeout = ''
@@ -227,8 +227,8 @@ for l in ivtest_lists:
 
             tests.append(
                 (
-                    name + '_iv', path, should_fail, type_, ' '.join(incdirs),
-                    timeout))
+                    name + '_iv', path, should_fail_because, type_,
+                    ' '.join(incdirs), timeout))
 
 test_dir = os.path.join(tests_dir, 'generated', tests_subdir)
 

--- a/generators/path_generator
+++ b/generators/path_generator
@@ -10,8 +10,8 @@ templ = """/*
 :description: Tests imported from {0}
 :files: {2}
 :incdirs: {4}
-:should_fail: {1}
 :tags: {0}{5}
+{1}
 */
 """
 
@@ -25,7 +25,7 @@ except KeyError:
 
 name = ''
 project = ''
-should_fail = ''
+should_fail_because = ''
 paths = [[]]
 matches = []
 
@@ -35,7 +35,9 @@ for cfg in glob.glob(os.path.join(conf_dir, 'generators', 'meta-path',
         data = json.load(jf)
         name = data['name']
         project = data['project']
-        should_fail = data['should_fail']
+        if 'should_fail_because' in data:
+            should_fail_because = ':should_fail_because: ' + data[
+                'should_fail_because']
         paths = data['paths']
         matches = data['matches']
         blacklist = data.get('blacklist', [''])
@@ -79,4 +81,5 @@ for cfg in glob.glob(os.path.join(conf_dir, 'generators', 'meta-path',
                 with open(test_file, "w") as sv:
                     sv.write(
                         templ.format(
-                            project, should_fail, f, fname, incs, timeout))
+                            project, should_fail_because, f, fname, incs,
+                            timeout))


### PR DESCRIPTION
This is related to https://github.com/SymbiFlow/sv-tests/issues/449

This PR does following things:
- remove all "should_fail: 0" statements because they are not needed (tests are assumed non-failing by default)
- change "should_fail: 1" tests to "should_fail_because" and add human-readable explanation