### PR TITLE
cgroups: Provide more default memory.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ THIRD_PARTY_DIR ?= ./third_party
 GENERATORS_DIR ?= ./generators
 
 USE_CGROUP := ${USE_CGROUP}
+CGROUP_MAX_MEMORY ?= 3221225472  # 3GiB
 
 export OUT_DIR
 export CONF_DIR
@@ -68,17 +69,17 @@ define runner_cg_gen
 ifneq ($(USE_CGROUP),)
 
 /sys/fs/cgroup/memory/$(USE_CGROUP)/$(1):
-	# Create a sub-cgroup for each runner under the sv-tests group.
-	cgcreate -g memory,cpu:sv-tests/$(1)
-	# Limit a single runner to using 2GB of memory
-	echo 2000000000 > /sys/fs/cgroup/memory/sv-tests/$(1)/memory.limit_in_bytes
+	# Create a sub-cgroup for each runner under the $(USE_CGROUP) group.
+	cgcreate -g memory,cpu:$(USE_CGROUP)/$(1)
 
 $(1)-cg: /sys/fs/cgroup/memory/$(USE_CGROUP)/$(1)
+	# Limit a single runner memory
+	echo $(CGROUP_MAX_MEMORY) > /sys/fs/cgroup/memory/$(USE_CGROUP)/$(1)/memory.limit_in_bytes
 
-endif
-
+else
 $(1)-cg:
 	@true
+endif
 
 endef
 

--- a/generators/black-parrot
+++ b/generators/black-parrot
@@ -11,7 +11,7 @@ templ = """/*
 :incdirs: {1}
 :top_module: {2}
 :tags: black-parrot
-:timeout: 100
+:timeout: 300
 */
 """
 


### PR DESCRIPTION
 * When run with cgroups, provide a little more memory to
   run the runners (3GiB vs ~2GiB). Can now also be set by
   CGROUP_MAX_MEMORY variable.
 * Use the USE_CGROUP variable everywhere (some places still
   used a hard-coded value)
 * Make sure the memory limit is initialized even if the
   cgroup already exists: this allows to experiment with
   different memory settings with each run.
 * don't create $(1)-cg: target twice (else/endif was missing)
 * Somewhat independent, but while at it: provide a little longer
   timeout to black-parrot.

Signed-off-by: Henner Zeller <h.zeller@acm.org>