### PR TITLE
Show bargraph for partially passing tests.

### DIFF
--- a/conf/report/report-template.html
+++ b/conf/report/report-template.html
@@ -100,6 +100,7 @@
           {% for tool, tooldata in report|dictsort %}
           <th class="report_table_result {{ tooldata["tags"][tag]["status"] }}
             {% if "test-na" not in tooldata["tags"][tag]["status"] %} test-cell {% endif %}"
+            {{ tooldata["tags"][tag]["optional_style"] }}
             {% if "test-na" not in tooldata["tags"][tag]["status"] %}
             id='{{tool}}-{{tag}}-cell'
             onclick='toggleLog("{{tool}}", "{{tag}}",

--- a/conf/report/report.css
+++ b/conf/report/report.css
@@ -79,7 +79,11 @@ tfoot .report_table_result {
   background-color: #89E894;
 }
 .test-varied {
-  background-color: #ffd761;
+  background-color: #ff6961;
+  /* a single green pixel with color #89e894 that we use to make a variable background 'bargraph' */
+  background-image:url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVQI12PoejEFAAQGAgeVHl+AAAAAAElFTkSuQmCC');
+  background-repeat:no-repeat;
+  background-size: 100% 100%;
 }
 .test-na {
   background-color: #cfcece;

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -404,9 +404,12 @@ def collect_logs(runner_name):
             elif all(tags[tag]["status"][0] == x for x in tags[tag]["status"]):
                 tags[tag]["status"] = tags[tag]["status"][0]
             else:
-                passed_percentage = 100.0 * passed_count / len(tags[tag]["status"])
+                passed_percentage = 100.0 * passed_count / len(
+                    tags[tag]["status"])
                 tags[tag]["status"] = "test-varied"
-                tags[tag]["optional_style"] = " style='background-size: {}% 100%'".format(passed_percentage)
+                tags[tag][
+                    "optional_style"] = " style='background-size: {:.1f}% 100%'".format(
+                        passed_percentage)
 
     if runner_data["passed_time"] == 0:
         runner_data["passed_throughput"] = 0

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -396,14 +396,17 @@ def collect_logs(runner_name):
                     continue
 
         for tag in tags:
-            tags[tag]["passed-num"] = tags[tag]["status"].count("test-passed")
+            passed_count = tags[tag]["status"].count("test-passed")
+            tags[tag]["passed-num"] = passed_count
 
             if len(tags[tag]["status"]) == 0:
                 tags[tag]["status"] = "test-na"
             elif all(tags[tag]["status"][0] == x for x in tags[tag]["status"]):
                 tags[tag]["status"] = tags[tag]["status"][0]
             else:
+                passed_percentage = 100.0 * passed_count / len(tags[tag]["status"])
                 tags[tag]["status"] = "test-varied"
+                tags[tag]["optional_style"] = " style='background-size: {}% 100%'".format(passed_percentage)
 
     if runner_data["passed_time"] == 0:
         runner_data["passed_throughput"] = 0


### PR DESCRIPTION
For all test categories that comprise of a bunch of tests,
we currently show 'yellow' if they only pass partially.

Given that there are some of these where there are hundreds
or even thousands of tests lumped together, this is a very
coarse grained representation.

Changed this to a bargraph representation: now the percentage
of the box that represents passing tests is green, the rest
red.

We're loosing a happy yellow color in the output, but gaining
much easier insight of fraactions on tests on first sight.

![bargraph-svtests](https://user-images.githubusercontent.com/140937/87102698-80d19580-c207-11ea-8bea-3b925acb5383.png)
