### PR TITLE
conf/report/log-template: make should_fail_because conditional

### DIFF
--- a/conf/report/log-template.html
+++ b/conf/report/log-template.html
@@ -10,7 +10,9 @@
 <pre class="{{status}}">
 description: {{description|e}}
 rc: {{rc|e}} (means success: {{tool_success|e}})
+{% if should_fail_because|length %}
 should_fail_because: {{should_fail_because|e}}
+{% endif %}
 tags: {{tags|e}}
 incdirs: {{incdirs|e}}
 top_module: {{top_module|e}}


### PR DESCRIPTION
We don't want empty should_fail_because in logs

Related to https://github.com/SymbiFlow/sv-tests/issues/915

Signed-off-by: Tomasz Jurtsch <tjurtsch@antmicro.com>