### PR TITLE
Use bargraph representation also in summary line.

### DIFF
--- a/conf/report/report-template.html
+++ b/conf/report/report-template.html
@@ -119,13 +119,13 @@
           <th class="report_summary_header" colspan="2"> Total tests passed </th>
 
           {% for tool, tooldata in report|dictsort %}
-          <th class="report_table_result" title="{{ tool.lower() }}" > {{ report[tool]["total"]["tests"] }}/{{ report[tool]["tests"].keys()|length }}</th>
+          <th class="report_table_result test-varied" style='background-size: {{'%0.0f'| format(100.0 * report[tool]["total"]["tests"] / report[tool]["tests"].keys()|length)}}%;' title="{{ tool.lower() }} ({{'%0.0f'| format(100.0 * report[tool]["total"]["tests"] / report[tool]["tests"].keys()|length)}}%)" > {{ report[tool]["total"]["tests"] }}/{{ report[tool]["tests"].keys()|length }}</th>
           {% endfor %}
         </tr>
         <tr class="report_summary_row">
           <th class="report_summary_header" colspan="2"> Total tags passed </th>
           {% for tool, tooldata in report|dictsort %}
-          <th class="report_table_result" title="{{ tool.lower() }}" > {{ report[tool]["total"]["tags"]}}/{{ report[tool]["total"]["tested_tags"]}}</th>
+          <th class="report_table_result test-varied" style='background-size: {{'%0.0f'| format(100.0 * report[tool]["total"]["tags"] / report[tool]["total"]["tested_tags"])}}%;' title="{{ tool.lower() }} ({{'%0.0f'| format(100.0 * report[tool]["total"]["tags"] / report[tool]["total"]["tested_tags"])}}%)" > {{ report[tool]["total"]["tags"]}}/{{ report[tool]["total"]["tested_tags"]}}</th>
           {% endfor %}
         </tr>
         <tr class="report_summary_row">

--- a/conf/report/report-template.html
+++ b/conf/report/report-template.html
@@ -114,18 +114,18 @@
           {% endfor %}
         </tr>
       {% endfor %}
-      <tfoot>
+      <tfoot class="report_footer">
         <tr class="report_summary_row">
           <th class="report_summary_header" colspan="2"> Total tests passed </th>
 
           {% for tool, tooldata in report|dictsort %}
-          <th class="report_table_result test-varied" style='background-size: {{'%0.0f'| format(100.0 * report[tool]["total"]["tests"] / report[tool]["tests"].keys()|length)}}%;' title="{{ tool.lower() }} ({{'%0.0f'| format(100.0 * report[tool]["total"]["tests"] / report[tool]["tests"].keys()|length)}}%)" > {{ report[tool]["total"]["tests"] }}/{{ report[tool]["tests"].keys()|length }}</th>
+          <th class="report_table_result test-varied" style='background-size: {{'%0.0f'| format(100.0 * report[tool]["total"]["tests"] / report[tool]["tests"].keys()|length)}}% 100%;' title="{{ tool.lower() }} ({{'%0.0f'| format(100.0 * report[tool]["total"]["tests"] / report[tool]["tests"].keys()|length)}}%)" > {{ report[tool]["total"]["tests"] }}/{{ report[tool]["tests"].keys()|length }}</th>
           {% endfor %}
         </tr>
         <tr class="report_summary_row">
           <th class="report_summary_header" colspan="2"> Total tags passed </th>
           {% for tool, tooldata in report|dictsort %}
-          <th class="report_table_result test-varied" style='background-size: {{'%0.0f'| format(100.0 * report[tool]["total"]["tags"] / report[tool]["total"]["tested_tags"])}}%;' title="{{ tool.lower() }} ({{'%0.0f'| format(100.0 * report[tool]["total"]["tags"] / report[tool]["total"]["tested_tags"])}}%)" > {{ report[tool]["total"]["tags"]}}/{{ report[tool]["total"]["tested_tags"]}}</th>
+          <th class="report_table_result test-varied" style='background-size: {{'%0.0f'| format(100.0 * report[tool]["total"]["tags"] / report[tool]["total"]["tested_tags"])}}% 100%;' title="{{ tool.lower() }} ({{'%0.0f'| format(100.0 * report[tool]["total"]["tags"] / report[tool]["total"]["tested_tags"])}}%)" > {{ report[tool]["total"]["tags"]}}/{{ report[tool]["total"]["tested_tags"]}}</th>
           {% endfor %}
         </tr>
         <tr class="report_summary_row">

--- a/conf/report/report.css
+++ b/conf/report/report.css
@@ -12,6 +12,10 @@ table.dataTable tfoot th {
   border-top: 0px;
 }
 
+.report_footer {
+  outline: 2px solid #505050;
+}
+
 .report_table_tag {
   text-align: left;
   width: 8em;
@@ -29,6 +33,9 @@ table.dataTable tfoot th {
 tfoot .report_table_result {
   font-weight: normal !important;
   text-align: right;
+  border: 1px;
+  border-color: #505050;
+  border-style: none none solid solid;
 }
 
 .report_summary_row {


### PR DESCRIPTION

... with a slightly nasty calculation directly in the template.

![summary-bargraph](https://user-images.githubusercontent.com/140937/87176670-47dd0380-c28f-11ea-8586-999c81b434bb.png)

Signed-off-by: Henner Zeller <h.zeller@acm.org>