### PR TITLE
Add editorconfig <https://editorconfig.org/> to ease contribution.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# Editor config file, see http://editorconfig.org/
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{h,cpp}]
+indent_size = 2
+
+[*.py]
+indent_size = 4
+
+[*.html]
+indent_size = 2
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
Editorconfig is understood by a large set of editors.

Signed-off-by: Henner Zeller <h.zeller@acm.org>