### PR TITLE
Fix process test

### DIFF
--- a/tests/chapter-9/9.7--process_cls_await.sv
+++ b/tests/chapter-9/9.7--process_cls_await.sv
@@ -9,7 +9,7 @@ module process_tb ();
 
 		foreach(job[i])
 			fork
-				automatic int k = j;
+				automatic int k = i;
 				begin
 					job[k] = process::self();
 					$display("process %d", k);


### PR DESCRIPTION
The iterator is defined as `i`, `j` is undeclared.