### PR TITLE
moore: add incdirs to moore_parse

### DIFF
--- a/tools/runners/moore_parse.py
+++ b/tools/runners/moore_parse.py
@@ -7,4 +7,9 @@ class moore_parse(moore):
 
     def prepare_run_cb(self, tmp_dir, params):
         self.cmd = [self.executable, '--syntax']
+
+        for incdir in params['incdirs']:
+            self.cmd.append('-I')
+            self.cmd.append(incdir)
+
         self.cmd += params['files']


### PR DESCRIPTION
`moore_parse` runner did not use `params['incdirs'] and cause false-negative failures on tests that do include other files.

This PR adds the necessary arguments just like used on `moore` runner.