### PR TITLE
Rename antmicro-yosys to yosys-sv

### DIFF
--- a/tools/runners/YosysSv.py
+++ b/tools/runners/YosysSv.py
@@ -3,9 +3,9 @@ import os
 from BaseRunner import BaseRunner
 
 
-class Antmicro_yosys(BaseRunner):
+class YosysSv(BaseRunner):
     def __init__(self):
-        super().__init__("antmicro-yosys", "antmicro-yosys")
+        super().__init__("yosys-sv", "antmicro-yosys")
 
         self.url = "http://www.clifford.at/yosys/"
 


### PR DESCRIPTION
The origin of the fork is not important from the perspective of
sv-tests.

Rename it to yosys-sv to make it clear that this is a yosys fork capable
of processing more SystemVerilog features and to make its column appear
right next to vanilla yosys.