### PR TITLE
Add typed localparam

### DIFF
--- a/tests/chapter-6/6.20.4--localparam.sv
+++ b/tests/chapter-6/6.20.4--localparam.sv
@@ -1,6 +1,6 @@
 /*
 :name: localparam
-:description: localparam tests
+:description: localparam without type specifier
 :tags: 6.20.4
 */
 module top();

--- a/tests/chapter-6/6.20.4--localparam_int.sv
+++ b/tests/chapter-6/6.20.4--localparam_int.sv
@@ -1,0 +1,8 @@
+/*
+:name: localparam_int
+:description: localparam integer type
+:tags: 6.20.4
+*/
+module top();
+	localparam int p = 123;
+endmodule

--- a/tests/chapter-6/6.20.4--localparam_logic.sv
+++ b/tests/chapter-6/6.20.4--localparam_logic.sv
@@ -1,0 +1,9 @@
+/*
+:name: localparam_logic
+:description: localparam with logic type
+:tags: 6.20.4
+*/
+module top();
+	localparam [10:0] p = 1 << 5;
+	localparam logic [10:0] q = 1 << 5;
+endmodule

--- a/tests/chapter-6/6.20.4--localparam_string.sv
+++ b/tests/chapter-6/6.20.4--localparam_string.sv
@@ -1,0 +1,9 @@
+/*
+:name: localparam_string
+:description: localparam string typed
+:tags: 6.20.4
+*/
+module top();
+	localparam s1 = "foo";
+	localparam string s2 = "bar";
+endmodule

--- a/tests/chapter-6/6.20.4--localparam_unsigned_int.sv
+++ b/tests/chapter-6/6.20.4--localparam_unsigned_int.sv
@@ -1,0 +1,8 @@
+/*
+:name: localparam_uint
+:description: localparam unsigned typed
+:tags: 6.20.4
+*/
+module top();
+	localparam int unsigned q = 123;
+endmodule


### PR DESCRIPTION
Looks like some tools are limited in types they accept for localparam. Add explicit tests for a few common types: int, int unsigned, logic and string.