### PR TITLE
Improve test results sorting

### DIFF
--- a/conf/report/report.js
+++ b/conf/report/report.js
@@ -77,20 +77,7 @@ $.fn.dataTable.ext.type.order['sv-id-desc'] = function (a, b) {
 
 $.fn.dataTable.ext.order['test-status'] = function ( settings, col ) {
   return this.api().column( col, {order:'index'} ).nodes().map( function ( td, i ) {
-
-    if (td.className.includes("test-passed")) {
-      return 1;
-    }
-
-    if (td.className.includes("test-failed")) {
-      return 2;
-    }
-
-    if (td.className.includes("test-varied")) {
-      return 3;
-    }
-
-    return 4;
+    return 1 - eval(td.textContent);
   });
 };
 


### PR DESCRIPTION
Sort by the percentage of tests passed.

Fixes #972

Expect it to look more or less like this (except this was tested for a single runner):
![2020-08-07-121701](https://user-images.githubusercontent.com/8438531/89635844-ec129400-d8a7-11ea-8189-8f57f2d27f20.png)