### PR TITLE
Fix sorting for cells without any tests

### DIFF
--- a/conf/report/report.js
+++ b/conf/report/report.js
@@ -77,7 +77,11 @@ $.fn.dataTable.ext.type.order['sv-id-desc'] = function (a, b) {
 
 $.fn.dataTable.ext.order['test-status'] = function ( settings, col ) {
   return this.api().column( col, {order:'index'} ).nodes().map( function ( td, i ) {
-    return 1 - eval(td.textContent);
+    p = eval(td.textContent)
+    if (typeof p !== 'undefined') {
+      return 1 - p;
+    }
+    return 2;
   });
 };
 


### PR DESCRIPTION
The sorting mechanism introduced in #986 was broken for cells without any tests (the gray cells). They would remain in place and would not be affected by sorting.

This PR fixes it.