### PR TITLE
Make tool names in the headers clickable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,13 @@ $(OUT_DIR)/logs/$(1)/version:
 versions: $(OUT_DIR)/logs/$(1)/version
 endef
 
+define runner_url_gen
+$(OUT_DIR)/logs/$(1)/url:
+	./tools/runner --runner $(1) --url --out $(OUT_DIR)/logs/$(1)/url
+
+urls: $(OUT_DIR)/logs/$(1)/url
+endef
+
 define generator_gen
 generate-$(1):
 	$(GENERATORS_DIR)/$(1) $(1)
@@ -130,7 +137,7 @@ tests:
 
 generate-tests:
 
-report: init tests versions
+report: init tests versions urls
 	./tools/sv-report --revision $(shell git rev-parse --short HEAD)
 	cp $(CONF_DIR)/report/*.css $(OUT_DIR)/report/
 	cp $(CONF_DIR)/report/*.js $(OUT_DIR)/report/
@@ -139,3 +146,4 @@ $(foreach g, $(GENERATORS), $(eval $(call generator_gen,$(g))))
 $(foreach r, $(RUNNERS),$(foreach t, $(TESTS),$(eval $(call runner_test_gen,$(r),$(t)))))
 $(foreach r, $(RUNNERS),$(eval $(call runner_cg_gen,$(r))))
 $(foreach r, $(RUNNERS),$(eval $(call runner_version_gen,$(r))))
+$(foreach r, $(RUNNERS),$(eval $(call runner_url_gen,$(r))))

--- a/conf/report/report-template.html
+++ b/conf/report/report-template.html
@@ -52,7 +52,9 @@
           <th>  </th>
           <th>  </th>
           {% for tool, tooldata in report|dictsort %}
-          <th title='{{ report[tool]["version"] }}'> {{ tool.lower() }} </th>
+          <th title='{{ report[tool]["version"] }}'>
+            <a class="tool_link" target=_blank href='{{ report[tool]["url"] }}'>{{ tool.lower() }}</a>
+          </th>
           {% endfor %}
         </tr>
       </thead>

--- a/conf/report/report.css
+++ b/conf/report/report.css
@@ -39,7 +39,7 @@ table.dataTable tfoot th {
   max-width: 30em;
 }
 
-.tag_link {
+.tag_link, .tool_link {
   color: black;
 }
 

--- a/tools/BaseRunner.py
+++ b/tools/BaseRunner.py
@@ -197,6 +197,14 @@ class BaseRunner:
         except (TypeError, NameError, OSError):
             return self.name
 
+    def get_url(self):
+        """Get the URL to the homepage of the runner
+
+        Returns a string with the URL
+        """
+
+        return self.url
+
     def get_top_module_or_guess(self, params):
         """ Get the top-level module from the params, or guess it
         """

--- a/tools/runner
+++ b/tools/runner
@@ -18,6 +18,7 @@ parser.add_argument("-r", "--runner", required=True)
 action = parser.add_mutually_exclusive_group(required=True)
 action.add_argument("-t", "--test")
 action.add_argument("-v", "--version", action="store_true")
+action.add_argument("-u", "--url", action="store_true")
 
 parser.add_argument("-o", "--out", required=True)
 parser.add_argument("-k", "--keep-tmp", action="store_true")
@@ -78,6 +79,13 @@ if args.version:
     version = runner_obj.get_version()
     with open(out, "w") as f:
         f.write(version)
+
+    sys.exit(0)
+
+if args.url:
+    url = runner_obj.get_url()
+    with open(out, "w") as f:
+        f.write(url)
 
     sys.exit(0)
 

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -500,6 +500,9 @@ try:
         with open(os.path.join(args.logs, r, "version")) as version_file:
             data[r]["version"] = version_file.read()
 
+        with open(os.path.join(args.logs, r, "url")) as url_file:
+            data[r]["url"] = url_file.read()
+
         for tag in data[r]["tags"]:
             tag_handle = data[r]["tags"][tag]
 


### PR DESCRIPTION
The effect is similar to #997, but this is for the tool headers:

![2020-08-14-121744](https://user-images.githubusercontent.com/8438531/90239662-30fa7580-de28-11ea-9476-4f7bfc82b957.png)

The columns can still be sorted by clicking on the order arrows (or anywhere in the cell except the text).

Fixes #957