### PR TITLE
9.3.4--block_names_par etc: Only check one Variable to appease Verilator

### DIFF
--- a/tests/chapter-9/9.3.4--block_names_par.sv
+++ b/tests/chapter-9/9.3.4--block_names_par.sv
@@ -5,12 +5,8 @@
 */
 module block_tb ();
 	reg a = 0;
-	reg b = 0;
-	reg c = 0;
 	initial
 		fork: name
 			a = 1;
-			b = 0;
-			c = 1;
 		join: name
 endmodule

--- a/tests/chapter-9/9.3.5--statement_labels_par.sv
+++ b/tests/chapter-9/9.3.5--statement_labels_par.sv
@@ -5,12 +5,8 @@
 */
 module block_tb ();
 	reg a = 0;
-	reg b = 0;
-	reg c = 0;
 	initial
 		name: fork
 			a = 1;
-			b = 0;
-			c = 1;
 		join: name
 endmodule


### PR DESCRIPTION
This modifies these tests to pass on Verilator (which doesn't support multiple parallel fork statements), but still checks what they are intended to test which is the block naming.   Many other tests still check the more complicated fork behavior.

Thanks
