### PR TITLE
class_tests: Fix missing predeclarations, etc

### DIFF
--- a/tests/generic/class/class_test_12.sv
+++ b/tests/generic/class/class_test_12.sv
@@ -3,5 +3,8 @@
 :description: Test
 :tags: 6.15 8.3
 */
+class Bar #(int X=0, int Y=1, int Z=2); endclass
+localparam x=3, y=4, z=5;
+
 class Foo #(int N=1, int P=2) extends Bar #(x,y,z);
 endclass

--- a/tests/generic/class/class_test_13.sv
+++ b/tests/generic/class/class_test_13.sv
@@ -3,5 +3,8 @@
 :description: Test
 :tags: 6.15 8.3
 */
+class Bar #(int X=0, int Y=1, int Z=2); endclass
+localparam x=3, y=4, z=5;
+
 class Foo #(int W=8, type Int=int) extends Bar #(x,y,z);
 endclass

--- a/tests/generic/class/class_test_19.sv
+++ b/tests/generic/class/class_test_19.sv
@@ -3,4 +3,9 @@
 :description: Test
 :tags: 6.15 8.3
 */
+package Package;
+class Bar #(int X=0, int Y=1, int Z=2); endclass
+endpackage
+localparam x=3, y=4, z=5;
+
 class Foo extends Package::Bar #(x,y,z); endclass

--- a/tests/generic/class/class_test_21.sv
+++ b/tests/generic/class/class_test_21.sv
@@ -3,4 +3,9 @@
 :description: Test
 :tags: 6.15 8.3
 */
+package Package;
+class Bar #(int X=0, int Y=1, int Z=2); endclass
+endpackage
+localparam x=3, y=4, z=5;
+
 class Foo extends Package::Bar #(x,y,z); endclass

--- a/tests/generic/class/class_test_36.sv
+++ b/tests/generic/class/class_test_36.sv
@@ -1,9 +1,0 @@
-/*
-:name: class_test_36
-:description: Test
-:tags: 6.15 8.3
-*/
-class foo;
-  import fedex_pkg::box;
-  import fedex_pkg::*;
-endclass

--- a/tests/generic/class/class_test_37.sv
+++ b/tests/generic/class/class_test_37.sv
@@ -1,9 +1,0 @@
-/*
-:name: class_test_37
-:description: Test
-:tags: 6.15 8.3
-*/
-virtual class foo extends bar;
-  import fedex_pkg::box;
-  import fedex_pkg::*;
-endclass

--- a/tests/generic/class/class_test_52.sv
+++ b/tests/generic/class/class_test_52.sv
@@ -3,6 +3,8 @@
 :description: Test
 :tags: 6.15 8.3
 */
+class uvm_sequence_item;
+endclass
 class how_wide #(type DT=int) extends uvm_sequence_item;
   localparam Max_int = {$bits(DT) - 1{1'b1}};
   localparam Min_int = {$bits(int) - $bits(DT){1'b1}};

--- a/tests/generic/class/class_test_8.sv
+++ b/tests/generic/class/class_test_8.sv
@@ -3,4 +3,7 @@
 :description: Test
 :tags: 6.15 8.3
 */
+class Bar #(int X=0, int Y=1, int Z=2); endclass
+localparam x=3, y=4, z=5;
+
 class Foo extends Bar #(x,y,z); endclass


### PR DESCRIPTION
This fixes some class tests that are not legal because they do not predeclare referenced classes.

Also class_test_36.sv and class_test_37.sv are removed, IEEE does not allow import directly into classes.

 