### PR TITLE
The :defines: test should test preprocessors

### DIFF
--- a/tests/chapter-5/5.6.4--compiler-directives-preprocessor-macro_0.sv
+++ b/tests/chapter-5/5.6.4--compiler-directives-preprocessor-macro_0.sv
@@ -2,6 +2,7 @@
 :name: compiler_directives_preprocessor_macro_0
 :description: Read preprocessing macro from template (:defines: marker)
 :tags: 5.6.4
+:type: preprocessing
 :defines: TEST_VAR
 */
 


### PR DESCRIPTION
Fixes: #1023