### PR TITLE
Make verilator-uhdm run all types of tests

### DIFF
--- a/tools/runners/UhdmVerilator.py
+++ b/tools/runners/UhdmVerilator.py
@@ -6,7 +6,7 @@ from BaseRunner import BaseRunner
 
 class UhdmVerilator(BaseRunner):
     def __init__(self):
-        super().__init__("verilator-uhdm", "verilator-uhdm", {"simulation"})
+        super().__init__("verilator-uhdm", "verilator-uhdm")
 
         self.url = "https://github.com/alainmarcel/uhdm-integration"
 
@@ -36,8 +36,11 @@ class UhdmVerilator(BaseRunner):
             f.write("\n")
 
             f.write(f'{self.executable} $@ || exit $?\n')
-            f.write(f'make -C {build_dir} -f Vtop.mk\n')
-            f.write(f'./vbuild/{build_exe}\n')
+
+            # compile and run the code only for simulation
+            if mode == 'simulation':
+                f.write(f'make -C {build_dir} -f Vtop.mk\n')
+                f.write(f'./vbuild/{build_exe}\n')
 
         # verilator executable is a script but it doesn't
         # have shell shebang on the first line


### PR DESCRIPTION
Simply feeding UHDM to Verilator allows us to see if we handle specific
types of nodes, so the Verilator-UHDM integration should run all types
of tests.

Fixes #1069

Signed-off-by: Tomasz Gorochowik <tgorochowik@antmicro.com>