### PR TITLE
Update verible linter command name

### DIFF
--- a/tools/runners/Verible.py
+++ b/tools/runners/Verible.py
@@ -3,7 +3,7 @@ from BaseRunner import BaseRunner
 
 class Verible(BaseRunner):
     def __init__(self):
-        super().__init__("verible", "verilog_syntax", {"parsing"})
+        super().__init__("verible", "verible-verilog-syntax", {"parsing"})
 
         self.url = "https://github.com/google/verible"
 


### PR DESCRIPTION
Switch to using the current in-use name rather than the deprecated one.

This should remove the warning:
```
*******************************************************************************
verilog_syntax is the deprecated name for verible-verilog-syntax.
executing /home/kbuilder/miniconda/envs/sv-test-env/bin/verible-verilog-syntax instead
*******************************************************************************
```