### PR TITLE
Blacklist yosys values.v which has too many digits to be legal.

### DIFF
--- a/conf/generators/meta-path/yosys-simple.json
+++ b/conf/generators/meta-path/yosys-simple.json
@@ -5,5 +5,5 @@
 		["tools", "yosys", "tests", "simple"]
 	],
 	"matches": ["*.v"],
-	"blacklist": ["hierdefparam.v", "memory.v"]
+	"blacklist": ["hierdefparam.v", "memory.v", "values.v"]
 }


### PR DESCRIPTION
This blacklists a yosys test with illegal numbers.
