### PR TITLE
Increase default timeout for UVM

### DIFF
--- a/tools/runner
+++ b/tools/runner
@@ -138,7 +138,7 @@ try:
             test_params.setdefault('files', test)
             test_params.setdefault('incdirs', os.path.dirname(test))
             test_params.setdefault('top_module', '')
-            test_params.setdefault('timeout', "10")
+            test_params.setdefault('timeout', "30")
             test_params.setdefault('type', 'parsing')
             test_params.setdefault(
                 'should_fail',


### PR DESCRIPTION
Now many tests includes UVM, so the default timeout may be too short.