### PR TITLE
Add :type: simulation

### DIFF
--- a/tests/chapter-18/18.5.1--explicit-external-constraint_1.sv
+++ b/tests/chapter-18/18.5.1--explicit-external-constraint_1.sv
@@ -3,6 +3,7 @@
 :description: explicit external constraint test
 :should_fail_because: explicit contraint needs to be defined
 :tags: 18.5.1
+:type: simulation
 */
 
 class a;

--- a/tests/chapter-18/18.5.10--variable-ordering_1.sv
+++ b/tests/chapter-18/18.5.10--variable-ordering_1.sv
@@ -3,6 +3,7 @@
 :description: variable ordering test
 :should_fail_because: randc vars are not allowed, they are always solved before any other
 :tags: 18.5.10
+:type: simulation
 */
 
 class a;

--- a/tests/chapter-18/18.5.14--soft-constraints_2.sv
+++ b/tests/chapter-18/18.5.14--soft-constraints_2.sv
@@ -3,6 +3,7 @@
 :description: soft constraints test
 :should_fail_because: Soft constraints can only be specified on random variables; they may not be specified for randc variables.
 :tags: 18.5.14
+:type: simulation
 */
 
 

--- a/tests/chapter-18/18.5.2--pure-constraint_2.sv
+++ b/tests/chapter-18/18.5.2--pure-constraint_2.sv
@@ -3,6 +3,7 @@
 :description: pure constraint test
 :should_fail_because: pure constraint must be implemented by non-virtual class
 :tags: 18.5.2
+:type: simulation
 */
 
 virtual class a;

--- a/tests/chapter-18/18.5.4--distribution_2.sv
+++ b/tests/chapter-18/18.5.4--distribution_2.sv
@@ -3,6 +3,7 @@
 :description: distribution test
 :should_fail_because: distribution shall not be applied to randc variables
 :tags: 18.5.4
+:type: simulation
 */
 
 class a;

--- a/tests/chapter-18/18.6.3--behavior-of-randomization-methods_4.sv
+++ b/tests/chapter-18/18.6.3--behavior-of-randomization-methods_4.sv
@@ -3,6 +3,7 @@
 :description: behavior of randomization methods test
 :should_fail_because: The randomize() method is built-in and cannot be overridden.
 :tags: 18.6.3
+:type: simulation
 */
 
 class a;

--- a/tests/chapter-18/18.6.3--behavior-of-randomization-methods_5.sv
+++ b/tests/chapter-18/18.6.3--behavior-of-randomization-methods_5.sv
@@ -3,6 +3,7 @@
 :description:  behavior of randomization methods test
 :should_fail_because: The randomize() method is built-in and cannot be overridden.
 :tags: 18.6.3 uvm
+:type: simulation
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.8--disabling-random-variables-with-rand_mode_4.sv
+++ b/tests/chapter-18/18.8--disabling-random-variables-with-rand_mode_4.sv
@@ -3,6 +3,7 @@
 :description: rand_mode() test
 :should_fail_because: The rand_mode() method is built-in and cannot be overridden.
 :tags: 18.8
+:type: simulation
 */
 
 class a1;

--- a/tests/chapter-18/18.8--disabling-random-variables-with-rand_mode_5.sv
+++ b/tests/chapter-18/18.8--disabling-random-variables-with-rand_mode_5.sv
@@ -3,6 +3,7 @@
 :description: rand_mode() test
 :should_fail_because: The rand_mode() method is built-in and cannot be overridden.
 :tags: 18.8 uvm
+:type: simulation
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.9--controlling-constraints-with-constraint_mode_1.sv
+++ b/tests/chapter-18/18.9--controlling-constraints-with-constraint_mode_1.sv
@@ -3,6 +3,7 @@
 :description: constraint_mode() test
 :should_fail_because: The constraint_mode() method is built-in and cannot be overridden.
 :tags: 18.8
+:type: simulation
 */
 
 class a;

--- a/tests/chapter-18/18.9--controlling-constraints-with-constraint_mode_2.sv
+++ b/tests/chapter-18/18.9--controlling-constraints-with-constraint_mode_2.sv
@@ -3,6 +3,7 @@
 :description: constraint_mode() test
 :should_fail_because: The constraint_mode() method is built-in and cannot be overridden.
 :tags: 18.9 uvm
+:type: simulation
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-6/6.19--enum_value_inv.sv
+++ b/tests/chapter-6/6.19--enum_value_inv.sv
@@ -4,6 +4,7 @@
 :should_fail_because: If the integer value expression is a sized literal constant, it shall be an error if the size is different from the enum base type, even if the value is within the representable range.
 :tags: 6.19
 :runner_verilator_flags: -Werror-WIDTH
+:type: simulation
 */
 module top();
 	// 6.19 says:

--- a/tests/generic/typedef/typedef_test_28__bad.sv
+++ b/tests/generic/typedef/typedef_test_28__bad.sv
@@ -3,6 +3,7 @@
 :description: Test
 :should_fail_because: missing forward typedef declaration, type_identifier does not resolve to a data type.
 :tags: 6.18
+:type: simulation
 */
 
 // 6.18 says:


### PR DESCRIPTION
This PR adds `:type: simulation` to some tests which should be failed by semantic error.

Signed-off-by: Naoya Hatta <dalance@gmail.com>