### PR TITLE
gclk functions require global clocking

### DIFF
--- a/conf/generators/templates/sampled-functions-gclk.json
+++ b/conf/generators/templates/sampled-functions-gclk.json
@@ -1,0 +1,29 @@
+{
+	"name": "sampled_functions",
+	"filename": "20.13--{0}.sv",
+	"template": [
+		"/*",
+		":name: {0}_function",
+		":description: ${0} test",
+		":tags: {1}",
+		":type: simulation parsing",
+		"*/",
+		"module top();",
+		"logic a, clk;",
+		"global clocking @(posedge clk); endclocking",
+		"assert property (@(posedge clk) ${0}(a)) else $info;",
+		"endmodule"
+	],
+	"values": [
+		["past_gclk", "20.13 16.9"],
+		["rose_gclk", "20.13 16.9"],
+		["fell_gclk", "20.13 16.9"],
+		["stable_gclk", "20.13 16.9"],
+		["changed_gclk", "20.13 16.9"],
+		["future_gclk", "20.13 16.9"],
+		["rising_gclk", "20.13 16.9"],
+		["falling_gclk", "20.13 16.9"],
+		["steady_gclk", "20.13 16.9"],
+		["changing_gclk", "20.13 16.9"]
+	]
+}

--- a/conf/generators/templates/sampled-functions.json
+++ b/conf/generators/templates/sampled-functions.json
@@ -10,8 +10,7 @@
 		"*/",
 		"module top();",
 		"logic a, clk;",
-		"always @(posedge clk)",
-		"$display(\"%d\", ${0}(a));",
+		"assert property (@(posedge clk) ${0}(a)) else $info;",
 		"endmodule"
 	],
 	"values": [
@@ -20,16 +19,6 @@
 		["fell", "20.13 16.9"],
 		["stable", "20.13 16.9"],
 		["changed", "20.13 16.9"],
-		["past", "20.13 16.9"],
-		["past_gclk", "20.13 16.9"],
-		["rose_gclk", "20.13 16.9"],
-		["fell_gclk", "20.13 16.9"],
-		["stable_gclk", "20.13 16.9"],
-		["changed_gclk", "20.13 16.9"],
-		["future_gclk", "20.13 16.9"],
-		["rising_gclk", "20.13 16.9"],
-		["falling_gclk", "20.13 16.9"],
-		["steady_gclk", "20.13 16.9"],
-		["changing_gclk", "20.13 16.9"]
+		["past", "20.13 16.9"]
 	]
 }


### PR DESCRIPTION
The $*_gclk functions per IEEE require global clocking to be legal.

Also these functions are only legal in assertion contexts in some simulators/formal tools.

Not done but advisable would be a test that checks tools error on gclk without global clocking defined.  I wouldn't check for only assertion contexts as many simulators e.g. Verilator don't care.

