### PR TITLE
Fix broken class tests

### DIFF
--- a/tests/generic/class/class_test_26.sv
+++ b/tests/generic/class/class_test_26.sv
@@ -3,4 +3,7 @@
 :description: Test
 :tags: 6.15 8.3
 */
+interface class Bar #(parameter N); endclass
+
+parameter int N = 1;
 class Foo implements Bar#(N); endclass

--- a/tests/generic/class/class_test_27.sv
+++ b/tests/generic/class/class_test_27.sv
@@ -3,4 +3,9 @@
 :description: Test
 :tags: 6.15 8.3
 */
+
+package Package;
+  interface class Bar #(parameter A, B); endclass
+endpackage
+
 class Foo implements Package::Bar#(1, 2); endclass

--- a/tests/generic/class/class_test_28.sv
+++ b/tests/generic/class/class_test_28.sv
@@ -3,4 +3,8 @@
 :description: Test
 :tags: 6.15 8.3
 */
+
+class Base; endclass
+interface class Bar; endclass
+
 class Foo extends Base implements Bar; endclass

--- a/tests/generic/class/class_test_29.sv
+++ b/tests/generic/class/class_test_29.sv
@@ -3,4 +3,12 @@
 :description: Test
 :tags: 6.15 8.3
 */
+
+package Pkg;
+  interface class Bar; endclass
+endpackage
+
+class Base; endclass
+interface class Baz; endclass
+
 class Foo extends Base implements Pkg::Bar, Baz; endclass

--- a/tests/generic/class/class_test_49.sv
+++ b/tests/generic/class/class_test_49.sv
@@ -3,6 +3,15 @@
 :description: Test
 :tags: 6.15 8.3
 */
+
+package glb;
+  localparam int arr[3] = '{1,2,3};
+endpackage
+
+function int f(int a);
+  return a;
+endfunction
+
 class params_as_class_item;
   parameter N = 2;
   parameter reg P = '1;

--- a/tests/generic/class/class_test_53.sv
+++ b/tests/generic/class/class_test_53.sv
@@ -3,10 +3,22 @@
 :description: Test
 :tags: 6.15 8.3
 */
+package mypkg;
+  typedef int GlueType;
+  class ModuleType #(parameter A); endclass
+endpackage
+
+typedef int BrickType;
+typedef int Ctype1;
+typedef int Ctype2;
+
+parameter int N = 1;
+parameter int M = 2;
+
 class param_types_as_class_item;
-  parameter type AT;
+  parameter type AT = int;
   parameter type BT = BrickType;
   parameter type CT1 = Ctype1, CT2 = Ctype2;
-  localparam type GT = mypkg::GlueType, GT2;
-  localparam type HT1, HT2 = mypkg::ModuleType#(N+M);
+  localparam type GT = mypkg::GlueType, GT2 = int;
+  localparam type HT1 = int, HT2 = mypkg::ModuleType#(N+M);
 endclass

--- a/tests/generic/class/class_test_58.sv
+++ b/tests/generic/class/class_test_58.sv
@@ -7,5 +7,5 @@ typedef int data_type_or_module_type;
 
 class fields_with_modifiers;
   const static data_type_or_module_type foo1 = 4'hf;
-  static const data_type_or_module_type foo3, foo4;
+  static const data_type_or_module_type foo3 = 1, foo4 = 2;
 endclass

--- a/tests/generic/class/class_test_7.sv
+++ b/tests/generic/class/class_test_7.sv
@@ -3,4 +3,8 @@
 :description: Test
 :tags: 6.15 8.3
 */
+package Package;
+  class Bar; endclass
+endpackage
+
 class Foo extends Package::Bar; endclass

--- a/tests/generic/iface/iface_class_test_9.sv
+++ b/tests/generic/iface/iface_class_test_9.sv
@@ -3,6 +3,8 @@
 :description: Test
 :tags: 8.3 8.26
 */
+typedef int arg_type;
+
 interface class base_ic;
 pure virtual task pure_task1;
 pure virtual task pure_task2(arg_type arg);

--- a/tests/generic/member/class_member_test_15.sv
+++ b/tests/generic/member/class_member_test_15.sv
@@ -6,3 +6,5 @@
 class myclass;
 extern function void subroutine;
 endclass
+
+function void myclass::subroutine; endfunction

--- a/tests/generic/member/class_member_test_18.sv
+++ b/tests/generic/member/class_member_test_18.sv
@@ -4,5 +4,8 @@
 :tags: 8.3
 */
 class myclass;
+typedef logic bool;
 extern function void subroutine(input bool x);
 endclass
+
+function void myclass::subroutine(input bool x); endfunction

--- a/tests/generic/member/class_member_test_19.sv
+++ b/tests/generic/member/class_member_test_19.sv
@@ -4,5 +4,9 @@
 :tags: 8.3
 */
 class myclass;
+typedef logic bool;
+localparam int N = 2;
 extern function void subr(bool x[N]);
 endclass
+
+function void myclass::subr(bool x[N]); endfunction

--- a/tests/generic/member/class_member_test_2.sv
+++ b/tests/generic/member/class_member_test_2.sv
@@ -6,3 +6,5 @@
 class myclass;
 extern task subtask(int arg);
 endclass
+
+task myclass::subtask(int arg); endtask

--- a/tests/generic/member/class_member_test_25.sv
+++ b/tests/generic/member/class_member_test_25.sv
@@ -6,3 +6,5 @@
 class myclass;
 extern virtual function integer subroutine;
 endclass
+
+function integer myclass::subroutine; endfunction

--- a/tests/generic/member/class_member_test_26.sv
+++ b/tests/generic/member/class_member_test_26.sv
@@ -3,7 +3,7 @@
 :description: Test
 :tags: 8.3
 */
-class myclass;
+virtual class myclass;
 pure virtual function integer subroutine;
 pure virtual function integer compute(int a, bit b);
 endclass

--- a/tests/generic/member/class_member_test_27.sv
+++ b/tests/generic/member/class_member_test_27.sv
@@ -3,6 +3,9 @@
 :description: Test
 :tags: 8.3
 */
+class report_server; endclass
+typedef int uvm_phase;
+
 class myclass;
 virtual function void starter(uvm_phase phase);
   report_server new_server = new;

--- a/tests/generic/member/class_member_test_3.sv
+++ b/tests/generic/member/class_member_test_3.sv
@@ -6,3 +6,5 @@
 class myclass;
 extern task subtask(int arg);
 endclass
+
+task myclass::subtask(int arg); endtask

--- a/tests/generic/member/class_member_test_31.sv
+++ b/tests/generic/member/class_member_test_31.sv
@@ -4,6 +4,9 @@
 :tags: 8.3
 */
 class myclass;
+int dout;
+int n_bits;
+
 function void shifter;
   for (int shft_idx=0, bit c=1'b1; shft_idx < n_bits;
        shft_idx++) begin

--- a/tests/generic/member/class_member_test_32.sv
+++ b/tests/generic/member/class_member_test_32.sv
@@ -4,6 +4,9 @@
 :tags: 8.3
 */
 class myclass;
+int dout;
+int n_bits;
+
 function void shifter;
   for (var int shft_idx=1, bit c=1'b0; shft_idx < n_bits;
        shft_idx++) begin

--- a/tests/generic/member/class_member_test_4.sv
+++ b/tests/generic/member/class_member_test_4.sv
@@ -6,3 +6,5 @@
 class myclass;
 extern virtual task subtask(int arg);
 endclass
+
+task myclass::subtask(int arg); endtask

--- a/tests/generic/member/class_member_test_5.sv
+++ b/tests/generic/member/class_member_test_5.sv
@@ -1,6 +1,7 @@
 /*
 :name: class_member_test_5
 :description: Test
+:should_fail_because: pure virtual methods can only be declared in virtual classes
 :tags: 8.3
 */
 class myclass;

--- a/tests/generic/member/class_member_test_6.sv
+++ b/tests/generic/member/class_member_test_6.sv
@@ -6,3 +6,5 @@
 class myclass;
 extern protected task subtask(int arg);
 endclass
+
+task myclass::subtask(int arg); endtask

--- a/tests/generic/member/class_member_test_7.sv
+++ b/tests/generic/member/class_member_test_7.sv
@@ -6,3 +6,5 @@
 class myclass;
 extern virtual protected task subtask(int arg);
 endclass
+
+task myclass::subtask(int arg); endtask

--- a/tests/generic/member/class_member_test_8.sv
+++ b/tests/generic/member/class_member_test_8.sv
@@ -6,3 +6,5 @@
 class myclass;
 extern protected virtual task subtask(int arg);
 endclass
+
+task myclass::subtask(int arg); endtask

--- a/tests/generic/member/class_member_test_9.sv
+++ b/tests/generic/member/class_member_test_9.sv
@@ -4,5 +4,8 @@
 :tags: 8.3
 */
 class myclass;
+typedef int arg_type;
 extern local static task subtask(arg_type arg);
 endclass
+
+task myclass::subtask(arg_type arg); endtask


### PR DESCRIPTION
A bunch of the class tests were invalid for various reasons; most of them because extern methods had no out-of-block implementation provided, or because undeclared types were used.