### PR TITLE
Make the default timeout smaller

### DIFF
--- a/tools/runner
+++ b/tools/runner
@@ -138,7 +138,7 @@ try:
             test_params.setdefault('files', test)
             test_params.setdefault('incdirs', os.path.dirname(test))
             test_params.setdefault('top_module', '')
-            test_params.setdefault('timeout', "30")
+            test_params.setdefault('timeout', "15")
             test_params.setdefault('type', 'parsing')
             test_params.setdefault(
                 'should_fail',


### PR DESCRIPTION
Unfortunately the increased timeout made Travis timeout (50 minute
limit). Until we migrate to github actions the test timeout has to be
smaller.

@dalance we do plan to migrate to github actions so we should be able to restore your change once it is done.