### PR TITLE
Add verible verilog kythe extractor runner

### DIFF
--- a/tools/runners.mk
+++ b/tools/runners.mk
@@ -117,10 +117,12 @@ $(INSTALL_DIR)/bin/moore:
 	cargo install --git "https://github.com/fabianschuiki/moore" --root $(INSTALL_DIR) --bin moore
 
 # verible
-verible: $(INSTALL_DIR)/bin/verilog_syntax
-
-$(INSTALL_DIR)/bin/verilog_syntax:
+verible:
 	cd $(RDIR)/verible/ && bazel run :install --noshow_progress -c opt -- $(INSTALL_DIR)/bin
+
+$(INSTALL_DIR)/bin/verible-verilog-kythe-extractor: verible
+
+$(INSTALL_DIR)/bin/verilog_syntax: verible
 
 # setup the dependencies
 RUNNERS_TARGETS := odin yosys icarus verilator slang zachjs-sv2v tree-sitter-verilog sv-parser moore verible surelog

--- a/tools/runners/VeribleExtractor.py
+++ b/tools/runners/VeribleExtractor.py
@@ -1,0 +1,37 @@
+from BaseRunner import BaseRunner
+
+import os
+import shlex
+
+
+class VeribleExtractor(BaseRunner):
+    def __init__(self):
+        super().__init__(
+            "verible_extractor", "verible-verilog-kythe-extractor",
+            {"parsing"})
+
+        self.url = "https://github.com/google/verible"
+
+    def prepare_run_cb(self, tmp_dir, params):
+        src_list_path = os.path.join(tmp_dir, "src_list")
+        script_path = os.path.join(tmp_dir, "run.sh")
+
+        with open(src_list_path, "w") as src_list:
+            print("\n".join(params.get("files", [])), file=src_list)
+
+        inc_dirs = ",".join(params.get("incdirs", []))
+
+        with open(script_path, "w") as script:
+            s = (
+                'log="$({executable}'
+                ' --file_list_root ""'
+                ' --include_dir_paths {inc_dirs}'
+                ' --file_list_path {src_list_path}'
+                ' 2>&1 1>/dev/null)"\n'
+                'if [ -n "$log" ]; then echo "$log"; exit 1; fi\n').format(
+                    executable=self.executable,
+                    inc_dirs=shlex.quote(inc_dirs),
+                    src_list_path=shlex.quote(src_list_path))
+            script.write(s)
+
+        self.cmd = ['sh', script_path]


### PR DESCRIPTION
This adds a runner for `verible-verilog-kythe-extractor`. It detects failure by checking if there were any log messages on stderr, as the tool's exit status is zero even for invalid files.

The verible submodule has been bumped manually, as `verible-verilog-kythe-extractor` changed significantly since the last bump (which happened more than a month ago).