### PR TITLE
Move tests needing assoc wildcards consistently under 7.8.1

### DIFF
--- a/tests/chapter-7/arrays/associative/other.sv
+++ b/tests/chapter-7/arrays/associative/other.sv
@@ -1,7 +1,7 @@
 /*
 :name: associative-arrays-other-types
 :description: Test associative arrays support
-:tags: 7.8.5 7.8
+:tags: 7.8.1
 */
 module top ();
 

--- a/tests/chapter-7/arrays/associative/wildcard.sv
+++ b/tests/chapter-7/arrays/associative/wildcard.sv
@@ -1,7 +1,7 @@
 /*
 :name: associative-arrays-wildcard
 :description: Test associative arrays support
-:tags: 7.8.1 7.8
+:tags: 7.8.1
 */
 module top ();
 


### PR DESCRIPTION
Trivial movement of tests needing wildcard associative arrays to be consistently in 7.8.1.
