### PR TITLE
Blacklist hdlconvertor tests that are not legal.

### DIFF
--- a/conf/generators/meta-path/hdlconvertor.json
+++ b/conf/generators/meta-path/hdlconvertor.json
@@ -3,8 +3,42 @@
 	"project": "hdlconv",
 	"paths": [
 		["tests", "hdlconvertor", "tests", "sv_test", "*"],
-		["tests", "hdlconvertor", "tests", "verilog"]
+		["tests", "hdlconvertor", "tests", "verilog", "*"]
 	],
 	"matches": ["*.sv", "*.v"],
-	"blacklist": ["p12.sv", "p940.sv", "p137.sv", "p552.sv"]
+	"blacklist": [
+		"adder_implicit.sv",
+		"directive_verilogpp.sv",
+		"fifo_rx.sv",
+		"p12.sv",
+		"p137.sv",
+		"p138.sv",
+		"p174_2.sv",
+		"p176.sv",
+		"p180_2.sv",
+		"p229.sv",
+		"p335.sv",
+		"p342.sv",
+		"p504.sv",
+		"p524.sv",
+		"p552.sv",
+		"p711.sv",
+		"p713.sv",
+		"p714.sv",
+		"p731.sv",
+		"p732.sv",
+		"p734.sv",
+		"p735.sv",
+		"p736.sv",
+		"p755.sv",
+		"p77.sv",
+		"p782.sv",
+		"p793.sv",
+		"p794.sv",
+		"p795.sv",
+		"p802.sv",
+		"p825.sv",
+		"p836.sv",
+		"p940.sv"
+	]
 }


### PR DESCRIPTION
This blacklists hdlconvertor tests that are not legal.
