### PR TITLE
Trigger GHA push action only on the master branch

### DIFF
--- a/.github/workflows/sv-tests-ci.yml
+++ b/.github/workflows/sv-tests-ci.yml
@@ -1,8 +1,10 @@
 name: sv-tests-ci
 
 on:
-   push:
-   pull_request:
+  push:
+    branches:
+      'master'
+  pull_request:
 
 jobs:
   Test:


### PR DESCRIPTION
Otherwise it seems to be triggered two times (push and PR) for each
dependabot PR (which pushes to dependabot specific branches without a
fork).