### PR TITLE
Report test completion date stamp.

### DIFF
--- a/conf/report/log-template.html
+++ b/conf/report/log-template.html
@@ -20,6 +20,7 @@ type: {{type|e}}
 mode: {{mode|e}}
 files: {{file_urls}}
 defines: {{defines|e}}
+completed: {{date_completed}}
 time_elapsed: {{'%0.3f'| format(time_elapsed|float)}}s
 ram usage: {{'%d'| format(ram_usage|int)}} KB
 </pre>

--- a/tools/runner
+++ b/tools/runner
@@ -8,6 +8,7 @@ import shutil
 import logging
 import argparse
 import tempfile
+from datetime import datetime
 from importlib import import_module
 from logparser import parseLog
 
@@ -217,6 +218,8 @@ try:
     test_params['user_time'] = user_time
     test_params['system_time'] = system_time
     test_params['ram_usage'] = ram_usage
+    test_params['date_completed'] = datetime.now().strftime(
+        "%Y-%m-%d %H:%M:%S")
 
     tool_should_fail = test_params["should_fail"] == "1"
     tool_failed = not tool_success

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -9,6 +9,7 @@ import argparse
 import logging
 import jinja2
 import csv
+import datetime
 import sys
 import os
 import re
@@ -279,6 +280,7 @@ def collect_logs(runner_name):
     # all tests info
     runner_data["tests"] = {}
     tests = runner_data["tests"]
+    runner_data["date_completed"] = ''
     runner_data["time_elapsed"] = 0
     runner_data["user_time"] = 0
     runner_data["system_time"] = 0
@@ -298,10 +300,11 @@ def collect_logs(runner_name):
         tests[t_id] = {}
 
         test_tags = [
-            "name", "tags", "should_fail", "rc", "description", "files",
-            "incdirs", "top_module", "runner", "runner_url", "time_elapsed",
-            "type", "mode", "timeout", "user_time", "system_time", "ram_usage",
-            "tool_success", "should_fail_because", "defines"
+            "name", "tags", "should_fail", "rc", "date_completed",
+            "description", "files", "incdirs", "top_module", "runner",
+            "runner_url", "time_elapsed", "type", "mode", "timeout",
+            "user_time", "system_time", "ram_usage", "tool_success",
+            "should_fail_because", "defines"
         ]
         with open(t, "r") as f:
             try:


### PR DESCRIPTION
When looking at failing tests on the dashboard it would be helpful to know how long since they last ran.  This adds a date stamp.
