### PR TITLE
Update UVM tags to uvm-random (#1146)

### DIFF
--- a/tests/chapter-18/18.10--dynamic-constraint-modification_0.sv
+++ b/tests/chapter-18/18.10--dynamic-constraint-modification_0.sv
@@ -1,7 +1,7 @@
 /*
 :name: dynamic_constraint_modification_0
 :description: dynamic constraint modification test
-:tags: uvm-18.10 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.11--in-line-random-variable-control_0.sv
+++ b/tests/chapter-18/18.11--in-line-random-variable-control_0.sv
@@ -1,7 +1,7 @@
 /*
 :name: in-line_random_variable-control_0
 :description: in-line random variable control test
-:tags: uvm-18.11 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.11--in-line-random-variable-control_1.sv
+++ b/tests/chapter-18/18.11--in-line-random-variable-control_1.sv
@@ -1,7 +1,7 @@
 /*
 :name: in-line_random_variable-control_1
 :description: in-line random variable control test
-:tags: uvm-18.11 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.11.1--in-line-constraint-checker_0.sv
+++ b/tests/chapter-18/18.11.1--in-line-constraint-checker_0.sv
@@ -1,7 +1,7 @@
 /*
 :name: in-line_constraint_checker_0
 :description: in-line constraint checker test
-:tags: uvm-18.11.1 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.11.1--in-line-constraint-checker_1.sv
+++ b/tests/chapter-18/18.11.1--in-line-constraint-checker_1.sv
@@ -1,7 +1,7 @@
 /*
 :name: in-line_constraint_checker_1
 :description: in-line constraint checker test
-:tags: uvm-18.11.1 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.12--randomization-of-scope-variables_1.sv
+++ b/tests/chapter-18/18.12--randomization-of-scope-variables_1.sv
@@ -1,7 +1,7 @@
 /*
 :name: randomization_of_scope_variables_1
 :description: Randomization of scope variables - std::randomize() test
-:tags: uvm-18.12 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.12.1--adding-constraints-to-scope-variables_1.sv
+++ b/tests/chapter-18/18.12.1--adding-constraints-to-scope-variables_1.sv
@@ -1,7 +1,7 @@
 /*
 :name: adding_constraints_to_scope_variables_1
 :description: Adding constraints to scope variables—std::randomize() with - test
-:tags: uvm-18.12.1 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.13.1--urandom_1.sv
+++ b/tests/chapter-18/18.13.1--urandom_1.sv
@@ -1,7 +1,7 @@
 /*
 :name: urandom_1
 :description: urandom() test
-:tags: uvm-18.13.1 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.13.1--urandom_3.sv
+++ b/tests/chapter-18/18.13.1--urandom_3.sv
@@ -1,7 +1,7 @@
 /*
 :name: urandom_3
 :description: urandom() test
-:tags: uvm-18.13.1 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.13.2--urandom_range_1.sv
+++ b/tests/chapter-18/18.13.2--urandom_range_1.sv
@@ -1,7 +1,7 @@
 /*
 :name: urandom_range_1
 :description: urandom_range() test
-:tags: uvm-18.13.2 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.13.2--urandom_range_2.sv
+++ b/tests/chapter-18/18.13.2--urandom_range_2.sv
@@ -1,7 +1,7 @@
 /*
 :name: urandom_range_2
 :description: urandom_range() test
-:tags: uvm-18.13.2 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.13.2--urandom_range_3.sv
+++ b/tests/chapter-18/18.13.2--urandom_range_3.sv
@@ -1,7 +1,7 @@
 /*
 :name: urandom_range_3
 :description: urandom_range() test
-:tags: uvm-18.13.2 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.13.3--srandom_0.sv
+++ b/tests/chapter-18/18.13.3--srandom_0.sv
@@ -1,7 +1,7 @@
 /*
 :name: srandom_0
 :description: srandom() test
-:tags: uvm-18.13.3 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.13.4--get_randstate_0.sv
+++ b/tests/chapter-18/18.13.4--get_randstate_0.sv
@@ -1,7 +1,7 @@
 /*
 :name: get_randstate_0
 :description: get_randstate() test
-:tags: uvm-18.13.4 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.13.5--set_randstate_0.sv
+++ b/tests/chapter-18/18.13.5--set_randstate_0.sv
@@ -1,7 +1,7 @@
 /*
 :name: set_randstate_0
 :description: set_randstate() test
-:tags: uvm-18.13.5 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.14--random-stability_0.sv
+++ b/tests/chapter-18/18.14--random-stability_0.sv
@@ -1,7 +1,7 @@
 /*
 :name: random_stability_0
 :description: random stability - urandom_range test
-:tags: uvm-18.14 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.14--random-stability_1.sv
+++ b/tests/chapter-18/18.14--random-stability_1.sv
@@ -1,7 +1,7 @@
 /*
 :name: random_stability_1
 :description: random stability - shuffle test
-:tags: uvm-18.14 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.14--random-stability_2.sv
+++ b/tests/chapter-18/18.14--random-stability_2.sv
@@ -1,7 +1,7 @@
 /*
 :name: random_stability_2
 :description: random stability - randcase test
-:tags: uvm-18.14 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.14--random-stability_3.sv
+++ b/tests/chapter-18/18.14--random-stability_3.sv
@@ -1,7 +1,7 @@
 /*
 :name: random_stability_3
 :description: random stability - randcase test
-:tags: uvm-18.14 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.14.2--thread-stability_0.sv
+++ b/tests/chapter-18/18.14.2--thread-stability_0.sv
@@ -1,7 +1,7 @@
 /*
 :name: thread_stability_0
 :description: thread stability test
-:tags: uvm-18.14.2 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.14.2--thread-stability_1.sv
+++ b/tests/chapter-18/18.14.2--thread-stability_1.sv
@@ -1,7 +1,7 @@
 /*
 :name: thread_stability_1
 :description: thread stability test
-:tags: uvm-18.14.2 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.14.3--object-stability_0.sv
+++ b/tests/chapter-18/18.14.3--object-stability_0.sv
@@ -1,7 +1,7 @@
 /*
 :name: object_stability_0
 :description: object stability test
-:tags: uvm-18.14.3 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.14.3--object-stability_1.sv
+++ b/tests/chapter-18/18.14.3--object-stability_1.sv
@@ -1,7 +1,7 @@
 /*
 :name: object_stability_1
 :description: object stability test
-:tags: uvm-18.14.3 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.15--manually-seeding-randomize_1.sv
+++ b/tests/chapter-18/18.15--manually-seeding-randomize_1.sv
@@ -1,7 +1,7 @@
 /*
 :name: manually_seeding_randomize_1
 :description: manually seeding randomize test
-:tags: uvm-18.15 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.16--random-weighted-case-randcase_1.sv
+++ b/tests/chapter-18/18.16--random-weighted-case-randcase_1.sv
@@ -1,7 +1,7 @@
 /*
 :name: random_weighted_case_randcase_1
 :description: randcase test
-:tags: uvm-18.16 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.16--random-weighted-case-randcase_3.sv
+++ b/tests/chapter-18/18.16--random-weighted-case-randcase_3.sv
@@ -1,7 +1,7 @@
 /*
 :name: random_weighted_case_randcase_3
 :description: randcase test
-:tags: uvm-18.16 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.17--random-sequence-generation-randsequence_1.sv
+++ b/tests/chapter-18/18.17--random-sequence-generation-randsequence_1.sv
@@ -1,7 +1,7 @@
 /*
 :name: random_sequence_generation_randsequence_1
 :description: randsequence test
-:tags: uvm-18.17 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.17--random-sequence-generation-randsequence_3.sv
+++ b/tests/chapter-18/18.17--random-sequence-generation-randsequence_3.sv
@@ -1,7 +1,7 @@
 /*
 :name: random-sequence-generation-randsequence_3
 :description: randsequence test
-:tags: uvm-18.17 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.17.1--random-production-weights_1.sv
+++ b/tests/chapter-18/18.17.1--random-production-weights_1.sv
@@ -1,7 +1,7 @@
 /*
 :name: random_production_weights_1
 :description: randsequence weights test
-:tags: uvm-18.17.1 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.17.2--if-else-production-statements_1.sv
+++ b/tests/chapter-18/18.17.2--if-else-production-statements_1.sv
@@ -1,7 +1,7 @@
 /*
 :name: if-else_production_statements_1
 :description: randcase if-else test
-:tags: uvm-18.17.2 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.17.2--if-else-production-statements_3.sv
+++ b/tests/chapter-18/18.17.2--if-else-production-statements_3.sv
@@ -1,7 +1,7 @@
 /*
 :name: if-else_production_statements_3
 :description: randcase if-else test
-:tags: uvm-18.17.2 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.17.3--case-production-statements_1.sv
+++ b/tests/chapter-18/18.17.3--case-production-statements_1.sv
@@ -1,7 +1,7 @@
 /*
 :name: case_production_statements_1
 :description: randcase case statement test
-:tags: uvm-18.17.3 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.17.4--repeat-production-statements_1.sv
+++ b/tests/chapter-18/18.17.4--repeat-production-statements_1.sv
@@ -1,7 +1,7 @@
 /*
 :name: repeat_production_statements_1
 :description: repeat statement test
-:tags: uvm-18.17.4 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.17.5--interleaving-productions-rand-join_1.sv
+++ b/tests/chapter-18/18.17.5--interleaving-productions-rand-join_1.sv
@@ -1,7 +1,7 @@
 /*
 :name: interleaving_productions_rand_join_1
 :description: rand join statement test
-:tags: uvm-18.17.5 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.17.5--interleaving-productions-rand-join_3.sv
+++ b/tests/chapter-18/18.17.5--interleaving-productions-rand-join_3.sv
@@ -1,7 +1,7 @@
 /*
 :name: interleaving_productions_rand_join_3
 :description: rand join statement test
-:tags: uvm-18.17.5 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.17.6--aborting-productions-break-and-return_1.sv
+++ b/tests/chapter-18/18.17.6--aborting-productions-break-and-return_1.sv
@@ -1,7 +1,7 @@
 /*
 :name: aborting_productions_break_and_return_1
 :description: break statement test
-:tags: uvm-18.17.6 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.17.6--aborting-productions-break-and-return_3.sv
+++ b/tests/chapter-18/18.17.6--aborting-productions-break-and-return_3.sv
@@ -1,7 +1,7 @@
 /*
 :name: aborting_productions_break_and_return_3
 :description: return statement test
-:tags: uvm-18.17.6 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.17.7--value-passing-between-productions_1.sv
+++ b/tests/chapter-18/18.17.7--value-passing-between-productions_1.sv
@@ -1,7 +1,7 @@
 /*
 :name: value_passing_between_productions_1
 :description: value passing in randsequence test
-:tags: uvm-18.17.7 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.5--constraint-blocks_1.sv
+++ b/tests/chapter-18/18.5--constraint-blocks_1.sv
@@ -1,7 +1,7 @@
 /*
 :name: constraint_blocks_1
 :description: constraint blocks test
-:tags: uvm-18.5 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.5.1--explicit-external-constraint_2.sv
+++ b/tests/chapter-18/18.5.1--explicit-external-constraint_2.sv
@@ -1,7 +1,7 @@
 /*
 :name: explicit_external_constraint_2
 :description: explicit external constraint test
-:tags: uvm-18.5.1 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.5.1--implicit-external-constraint_2.sv
+++ b/tests/chapter-18/18.5.1--implicit-external-constraint_2.sv
@@ -1,7 +1,7 @@
 /*
 :name: implicit_external_constraint_2
 :description: implicit external constraint test
-:tags: uvm-18.5.1 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.5.11--static-constraint-blocks_1.sv
+++ b/tests/chapter-18/18.5.11--static-constraint-blocks_1.sv
@@ -1,7 +1,7 @@
 /*
 :name: static_constraint_blocks_1
 :description: static constraint blocks test
-:tags: uvm-18.5.11 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.5.12--functions-in-constraint_1.sv
+++ b/tests/chapter-18/18.5.12--functions-in-constraint_1.sv
@@ -1,7 +1,7 @@
 /*
 :name: functions_in_constraint_1
 :description: functions in constraint test
-:tags: uvm-18.5.12 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.5.13--constraint-guards_1.sv
+++ b/tests/chapter-18/18.5.13--constraint-guards_1.sv
@@ -1,7 +1,7 @@
 /*
 :name: constraint_guards_1
 :description: constraint guards test
-:tags: uvm-18.5.13 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.5.14--soft-constraints_1.sv
+++ b/tests/chapter-18/18.5.14--soft-constraints_1.sv
@@ -1,7 +1,7 @@
 /*
 :name: soft_constraints_1
 :description: soft constraints test
-:tags: uvm-18.5.14 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.5.14.1--soft-constraint-priorities_1.sv
+++ b/tests/chapter-18/18.5.14.1--soft-constraint-priorities_1.sv
@@ -1,7 +1,7 @@
 /*
 :name: soft_constraint_priorities_1
 :description: soft constraint priorities test
-:tags: uvm-18.5.14.1 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.5.14.1--soft-constraint-priorities_3.sv
+++ b/tests/chapter-18/18.5.14.1--soft-constraint-priorities_3.sv
@@ -1,7 +1,7 @@
 /*
 :name: soft_constraint_priorities_3
 :description: soft constraint priorities test
-:tags: uvm-18.5.14.1 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.5.14.1--soft-constraint-priorities_4.sv
+++ b/tests/chapter-18/18.5.14.1--soft-constraint-priorities_4.sv
@@ -1,7 +1,7 @@
 /*
 :name: soft_constraint_priorities_4
 :description: soft constraint priorities test
-:tags: uvm-18.5.14.1 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.5.14.2--discarding-soft-constraints_1.sv
+++ b/tests/chapter-18/18.5.14.2--discarding-soft-constraints_1.sv
@@ -1,7 +1,7 @@
 /*
 :name: discarding_soft_constraints_1
 :description: discarding soft constraints test
-:tags: uvm-18.5.14.2 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.5.14.2--discarding-soft-constraints_3.sv
+++ b/tests/chapter-18/18.5.14.2--discarding-soft-constraints_3.sv
@@ -1,7 +1,7 @@
 /*
 :name: discarding_soft_constraints_3
 :description: discarding soft constraints test
-:tags: uvm-18.5.14.2 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.5.14.2--discarding-soft-constraints_5.sv
+++ b/tests/chapter-18/18.5.14.2--discarding-soft-constraints_5.sv
@@ -1,7 +1,7 @@
 /*
 :name: discarding_soft_constraints_5
 :description: discarding soft constraints test
-:tags: uvm-18.5.14.2 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.5.2--constraint-inheritance_1.sv
+++ b/tests/chapter-18/18.5.2--constraint-inheritance_1.sv
@@ -1,7 +1,7 @@
 /*
 :name: constraint_inheritance_1
 :description: contraint inheritance test
-:tags: uvm-18.5.2 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.5.2--pure-constraint_1.sv
+++ b/tests/chapter-18/18.5.2--pure-constraint_1.sv
@@ -1,7 +1,7 @@
 /*
 :name: pure_constraint_1
 :description: pure constraint test
-:tags: uvm-18.5.2 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.5.3--set-membership_1.sv
+++ b/tests/chapter-18/18.5.3--set-membership_1.sv
@@ -1,7 +1,7 @@
 /*
 :name: set_membership_1
 :description: set membership test
-:tags: uvm-18.5.3 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.5.4--distribution_1.sv
+++ b/tests/chapter-18/18.5.4--distribution_1.sv
@@ -1,7 +1,7 @@
 /*
 :name: distribution_1
 :description: distribution test
-:tags: uvm-18.5.4 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.5.5--uniqueness-constraints_1.sv
+++ b/tests/chapter-18/18.5.5--uniqueness-constraints_1.sv
@@ -1,7 +1,7 @@
 /*
 :name: uniqueness_constraints_1
 :description: uniqueness constraints test
-:tags: uvm-18.5.5 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.5.6--implication_1.sv
+++ b/tests/chapter-18/18.5.6--implication_1.sv
@@ -1,7 +1,7 @@
 /*
 :name: implication_1
 :description: implication test
-:tags: uvm-18.5.6 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.5.7--if-else-constraints_4.sv
+++ b/tests/chapter-18/18.5.7--if-else-constraints_4.sv
@@ -1,7 +1,7 @@
 /*
 :name: if_else_constraints_4
 :description: if-else constraints test
-:tags: uvm-18.5.7 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.5.8.1--foreach-iterative-constraints_1.sv
+++ b/tests/chapter-18/18.5.8.1--foreach-iterative-constraints_1.sv
@@ -1,7 +1,7 @@
 /*
 :name: foreach_iterative_constraints_1
 :description: foreach iterative constraints test
-:tags: uvm-18.5.8.1 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.5.8.2--array-reduction-iterative-constraints_1.sv
+++ b/tests/chapter-18/18.5.8.2--array-reduction-iterative-constraints_1.sv
@@ -1,7 +1,7 @@
 /*
 :name: array_reduction_iterative_constraints_1
 :description: array reduction iterative constraints test
-:tags: uvm-18.5.8.2 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.5.9--global-constraints_1.sv
+++ b/tests/chapter-18/18.5.9--global-constraints_1.sv
@@ -1,7 +1,7 @@
 /*
 :name: global_constraints_1
 :description: global constraints test
-:tags: uvm-18.5.9 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.6.1--randomize-method_0.sv
+++ b/tests/chapter-18/18.6.1--randomize-method_0.sv
@@ -1,7 +1,7 @@
 /*
 :name: randomize_method_0
 :description: randomize() method test
-:tags: uvm-18.6.1 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.6.2--post-randomize_method_1.sv
+++ b/tests/chapter-18/18.6.2--post-randomize_method_1.sv
@@ -1,7 +1,7 @@
 /*
 :name: post_randomize_method_1
 :description: post_randomize() method test
-:tags: uvm-18.6.2 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.6.2--pre-randomize-method_1.sv
+++ b/tests/chapter-18/18.6.2--pre-randomize-method_1.sv
@@ -1,7 +1,7 @@
 /*
 :name: pre_randomize_method_1
 :description: pre_randomize() method test
-:tags: uvm-18.6.2 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.6.3--behavior-of-randomization-methods_1.sv
+++ b/tests/chapter-18/18.6.3--behavior-of-randomization-methods_1.sv
@@ -1,7 +1,7 @@
 /*
 :name: behavior_of_randomization_methods_1
 :description: static random variables test
-:tags: uvm-18.6.3 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.6.3--behavior-of-randomization-methods_2.sv
+++ b/tests/chapter-18/18.6.3--behavior-of-randomization-methods_2.sv
@@ -1,7 +1,7 @@
 /*
 :name: behavior_of_randomization_methods_2
 :description: If randomize() fails, the constraints are infeasible, and the random variables retain their previous values.
-:tags: uvm-18.6.3 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.6.3--behavior-of-randomization-methods_3.sv
+++ b/tests/chapter-18/18.6.3--behavior-of-randomization-methods_3.sv
@@ -1,7 +1,7 @@
 /*
 :name: behavior_of_randomization_methods_3
 :description: If randomize() fails, post_randomize() is not called.
-:tags: uvm-18.6.3 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.6.3--behavior-of-randomization-methods_5.sv
+++ b/tests/chapter-18/18.6.3--behavior-of-randomization-methods_5.sv
@@ -2,7 +2,7 @@
 :name: behavior_of_randomization_methods_5
 :description:  behavior of randomization methods test
 :should_fail_because: The randomize() method is built-in and cannot be overridden.
-:tags: uvm-18.6.3 uvm
+:tags: uvm-random uvm
 :type: simulation
 */
 

--- a/tests/chapter-18/18.7--in-line-constraints--randomize_0.sv
+++ b/tests/chapter-18/18.7--in-line-constraints--randomize_0.sv
@@ -1,7 +1,7 @@
 /*
 :name: in-line_constraints--randomize_0
 :description: in-line constraints test - randomize()
-:tags: uvm-18.7 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.7--in-line-constraints--randomize_2.sv
+++ b/tests/chapter-18/18.7--in-line-constraints--randomize_2.sv
@@ -1,7 +1,7 @@
 /*
 :name: in-line_constraints--randomize_2
 :description: in-line constraints test - randomize()
-:tags: uvm-18.7 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.7--in-line-constraints--randomize_4.sv
+++ b/tests/chapter-18/18.7--in-line-constraints--randomize_4.sv
@@ -1,7 +1,7 @@
 /*
 :name: in-line_constraints--randomize_4
 :description: in-line constraints test - randomize()
-:tags: uvm-18.7 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.7--in-line-constraints--randomize_6.sv
+++ b/tests/chapter-18/18.7--in-line-constraints--randomize_6.sv
@@ -1,7 +1,7 @@
 /*
 :name: in-line_constraints--randomize_6
 :description: in-line constraints test - randomize()
-:tags: uvm-18.7 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.7.1--local-scope-resolution_1.sv
+++ b/tests/chapter-18/18.7.1--local-scope-resolution_1.sv
@@ -1,7 +1,7 @@
 /*
 :name: local_scope_resolution_1
 :description: local:: scope resolution test
-:tags: uvm-18.7.1 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.8--disabling-random-variables-with-rand_mode_0.sv
+++ b/tests/chapter-18/18.8--disabling-random-variables-with-rand_mode_0.sv
@@ -1,7 +1,7 @@
 /*
 :name: disabling-random-variables-with-rand_mode_0
 :description: rand_mode() test
-:tags: uvm-18.8 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.8--disabling-random-variables-with-rand_mode_1.sv
+++ b/tests/chapter-18/18.8--disabling-random-variables-with-rand_mode_1.sv
@@ -1,7 +1,7 @@
 /*
 :name: disabling-random-variables-with-rand_mode_1
 :description: rand_mode() test
-:tags: uvm-18.8 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.8--disabling-random-variables-with-rand_mode_2.sv
+++ b/tests/chapter-18/18.8--disabling-random-variables-with-rand_mode_2.sv
@@ -1,7 +1,7 @@
 /*
 :name: disabling-random-variables-with-rand_mode_2
 :description: rand_mode() test
-:tags: uvm-18.8 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.8--disabling-random-variables-with-rand_mode_3.sv
+++ b/tests/chapter-18/18.8--disabling-random-variables-with-rand_mode_3.sv
@@ -1,7 +1,7 @@
 /*
 :name: disabling-random-variables-with-rand_mode_3
 :description: rand_mode() test
-:tags: uvm-18.8 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.8--disabling-random-variables-with-rand_mode_5.sv
+++ b/tests/chapter-18/18.8--disabling-random-variables-with-rand_mode_5.sv
@@ -2,7 +2,7 @@
 :name: disabling-random-variables-with-rand_mode_5
 :description: rand_mode() test
 :should_fail_because: The rand_mode() method is built-in and cannot be overridden.
-:tags: uvm-18.8 uvm
+:tags: uvm-random uvm
 :type: simulation
 */
 

--- a/tests/chapter-18/18.9--controlling-constraints-with-constraint_mode_0.sv
+++ b/tests/chapter-18/18.9--controlling-constraints-with-constraint_mode_0.sv
@@ -1,7 +1,7 @@
 /*
 :name: controlling-constraints-with-constraint_mode_0
 :description: constraint_mode() test
-:tags: uvm-18.9 uvm
+:tags: uvm-random uvm
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.9--controlling-constraints-with-constraint_mode_2.sv
+++ b/tests/chapter-18/18.9--controlling-constraints-with-constraint_mode_2.sv
@@ -2,7 +2,7 @@
 :name: controlling-constraints-with-constraint_mode_2
 :description: constraint_mode() test
 :should_fail_because: The constraint_mode() method is built-in and cannot be overridden.
-:tags: uvm-18.9 uvm
+:tags: uvm-random uvm
 :type: simulation
 */
 


### PR DESCRIPTION
Per comment in #1146 moves tags to all be uvm-random as the current per-section tags in the dashboard don't look good.
