### PR TITLE
Do not use the obsolete regress-v10.list in ivtest

### DIFF
--- a/generators/ivtest
+++ b/generators/ivtest
@@ -35,7 +35,7 @@ type_should_fail = ['CE', 'RE']
 
 ivtest_exclude = [
     'regress-vams.list', 'regress-vhdl.list', 'vhdl_regress.list',
-    'vpi_regress.list', 'regress-ivl1.list'
+    'vpi_regress.list', 'regress-ivl1.list', 'regress-v10.list'
 ]
 
 ivtest_blacklist = [


### PR DESCRIPTION
There likely needs to be some more tweaks added to how the list files are handled but I think this should fix the merge issue in #1205