### PR TITLE
Fix syntax error of inside expression

### DIFF
--- a/tests/chapter-18/18.5.5--uniqueness-constraints_0.sv
+++ b/tests/chapter-18/18.5.5--uniqueness-constraints_0.sv
@@ -6,6 +6,7 @@
 
 class a;
     rand int b1, b2;
-    constraint c1 { b1, b2 inside {3, 10}; }
-    constraint c2 { unique {b1, b2}; }
+    constraint c1 { b1 inside {3, 10}; }
+    constraint c2 { b2 inside {3, 10}; }
+    constraint c3 { unique {b1, b2}; }
 endclass


### PR DESCRIPTION
inside_expression can take a expression at the left side of `inside`.
Therefore `b1, b2` can't be taken.

```
inside_expression ::= expression inside { open_range_list }
```

Signed-off-by: Naoya Hatta <dalance@gmail.com>