### PR TITLE
Conda channels fix

### DIFF
--- a/.github/workflows/install.sh
+++ b/.github/workflows/install.sh
@@ -14,7 +14,7 @@ hash -r
 conda config --set always_yes yes --set changeps1 no
 
 # Uncomment the correct runner
-sed -e"s/^#  - $JOB_NAME$/  - $JOB_NAME/" -i conf/environment.yml
+sed -e"/^#  - .*::$JOB_NAME$/ { s/^#// }" -i conf/environment.yml
 git diff
 
 conda env create --file conf/environment.yml

--- a/conf/environment.yml
+++ b/conf/environment.yml
@@ -4,20 +4,20 @@ channels:
   - pkgw-forge
   - conda-forge
 dependencies:
-#  - iverilog
-#  - moore
-#  - odin_ii
-#  - slang
-#  - surelog
-#  - sv-parser
-#  - tree-sitter-verilog
-#  - uhdm-integration-verilator
-#  - uhdm-integration-yosys
-#  - verible
-#  - verilator
-#  - yosys
-#  - antmicro-yosys
-#  - zachjs-sv2v
+#  - symbiflow::iverilog
+#  - symbiflow::moore
+#  - symbiflow::odin_ii
+#  - symbiflow::slang
+#  - symbiflow::surelog
+#  - symbiflow::sv-parser
+#  - symbiflow::tree-sitter-verilog
+#  - symbiflow::uhdm-integration-verilator
+#  - symbiflow::uhdm-integration-yosys
+#  - symbiflow::verible
+#  - symbiflow::verilator
+#  - symbiflow::yosys
+#  - symbiflow::antmicro-yosys
+#  - symbiflow::zachjs-sv2v
   - ccache
   - python=3.8
   - pip


### PR DESCRIPTION
This PR is fixing old verilator version in conda environment. Basically, conda was getting this package from channel `conda-forge` instead of `symbiflow`. I forced all packages listed as jobs to be fetched from channel symbiflow. Additionally I also had to change `sed` command in `install.sh` to take into account new dependency format while uncommenting packages.

Creating this as draft in order to make sure that CI is ok.