### PR TITLE
kokoro: Push to SymbiFlow/sv-tests-results repository.

### DIFF
--- a/.github/kokoro/run.sh
+++ b/.github/kokoro/run.sh
@@ -99,7 +99,7 @@ if [[ $KOKORO_TYPE = continuous ]]; then
 		echo
 		echo "Cloning the repo to deploy..."
 		git clone \
-			git+ssh://github.com/SymbiFlow/sv-tests.git \
+			git+ssh://github.com/SymbiFlow/sv-tests-results.git \
 			--reference $GIT_CHECKOUT \
 			--single-branch \
 			--depth 1 \
@@ -131,7 +131,7 @@ EOF
 		echo
 		echo "Pushing..."
 		git push \
-			git+ssh://github.com/SymbiFlow/sv-tests.git \
+			git+ssh://github.com/SymbiFlow/sv-tests-results.git \
 			gh-pages
 	)
 	echo "----------------------------------------"


### PR DESCRIPTION
As the HTML results being in the gh-pages branch end up with a rather
large and slow to clone repository, the results have been moved to their
own repository.

This makes the CI push to that repository instead.

Fixes #1179.

Signed-off-by: Tim 'mithro' Ansell <me@mith.ro>