### PR TITLE
Update class tests to have a module definition

### DIFF
--- a/tests/generic/class/class_test_0.sv
+++ b/tests/generic/class/class_test_0.sv
@@ -4,3 +4,6 @@
 :tags: 6.15 8.3
 */
 class semicolon_classy; ; ;;; ; ; ;endclass
+
+module test;
+endmodule

--- a/tests/generic/class/class_test_1.sv
+++ b/tests/generic/class/class_test_1.sv
@@ -4,3 +4,6 @@
 :tags: 6.15 8.3
 */
 class Foo; endclass
+
+module test;
+endmodule

--- a/tests/generic/class/class_test_11.sv
+++ b/tests/generic/class/class_test_11.sv
@@ -5,3 +5,6 @@
 */
 class Foo #(int N, int P);
 endclass
+
+module test;
+endmodule

--- a/tests/generic/class/class_test_12.sv
+++ b/tests/generic/class/class_test_12.sv
@@ -8,3 +8,6 @@ localparam x=3, y=4, z=5;
 
 class Foo #(int N=1, int P=2) extends Bar #(x,y,z);
 endclass
+
+module test;
+endmodule

--- a/tests/generic/class/class_test_13.sv
+++ b/tests/generic/class/class_test_13.sv
@@ -8,3 +8,6 @@ localparam x=3, y=4, z=5;
 
 class Foo #(int W=8, type Int=int) extends Bar #(x,y,z);
 endclass
+
+module test;
+endmodule

--- a/tests/generic/class/class_test_17.sv
+++ b/tests/generic/class/class_test_17.sv
@@ -5,3 +5,6 @@
 */
 class Foo #(type IFType=virtual x_if);
 endclass
+
+module test;
+endmodule

--- a/tests/generic/class/class_test_18.sv
+++ b/tests/generic/class/class_test_18.sv
@@ -5,3 +5,6 @@
 */
 class Foo #(type IFType=virtual interface x_if);
 endclass
+
+module test;
+endmodule

--- a/tests/generic/class/class_test_19.sv
+++ b/tests/generic/class/class_test_19.sv
@@ -9,3 +9,6 @@ endpackage
 localparam x=3, y=4, z=5;
 
 class Foo extends Package::Bar #(x,y,z); endclass
+
+module test;
+endmodule

--- a/tests/generic/class/class_test_21.sv
+++ b/tests/generic/class/class_test_21.sv
@@ -9,3 +9,6 @@ endpackage
 localparam x=3, y=4, z=5;
 
 class Foo extends Package::Bar #(x,y,z); endclass
+
+module test;
+endmodule

--- a/tests/generic/class/class_test_25.sv
+++ b/tests/generic/class/class_test_25.sv
@@ -4,3 +4,6 @@
 :tags: 6.15 8.3
 */
 class Foo implements Package::Bar; endclass
+
+module test;
+endmodule

--- a/tests/generic/class/class_test_26.sv
+++ b/tests/generic/class/class_test_26.sv
@@ -7,3 +7,6 @@ interface class Bar #(parameter N); endclass
 
 parameter int N = 1;
 class Foo implements Bar#(N); endclass
+
+module test;
+endmodule

--- a/tests/generic/class/class_test_27.sv
+++ b/tests/generic/class/class_test_27.sv
@@ -9,3 +9,6 @@ package Package;
 endpackage
 
 class Foo implements Package::Bar#(1, 2); endclass
+
+module test;
+endmodule

--- a/tests/generic/class/class_test_28.sv
+++ b/tests/generic/class/class_test_28.sv
@@ -8,3 +8,6 @@ class Base; endclass
 interface class Bar; endclass
 
 class Foo extends Base implements Bar; endclass
+
+module test;
+endmodule

--- a/tests/generic/class/class_test_29.sv
+++ b/tests/generic/class/class_test_29.sv
@@ -12,3 +12,6 @@ class Base; endclass
 interface class Baz; endclass
 
 class Foo extends Base implements Pkg::Bar, Baz; endclass
+
+module test;
+endmodule

--- a/tests/generic/class/class_test_30.sv
+++ b/tests/generic/class/class_test_30.sv
@@ -16,3 +16,6 @@ task print();
   end
 endtask
 endclass
+
+module test;
+endmodule

--- a/tests/generic/class/class_test_4.sv
+++ b/tests/generic/class/class_test_4.sv
@@ -4,3 +4,6 @@
 :tags: 6.15 8.3
 */
 virtual class Foo; endclass
+
+module test;
+endmodule

--- a/tests/generic/class/class_test_48.sv
+++ b/tests/generic/class/class_test_48.sv
@@ -6,3 +6,6 @@
 class pp_as_class_item;
  `undef EVIL_MACRO
 endclass
+
+module test;
+endmodule

--- a/tests/generic/class/class_test_49.sv
+++ b/tests/generic/class/class_test_49.sv
@@ -17,3 +17,6 @@ class params_as_class_item;
   parameter reg P = '1;
   localparam M = f(glb::arr[N]) + 1;
 endclass
+
+module test;
+endmodule

--- a/tests/generic/class/class_test_51.sv
+++ b/tests/generic/class/class_test_51.sv
@@ -6,3 +6,6 @@
 class how_wide;
   localparam Max_int = {$bits(int) - 1{1'b1}};
 endclass
+
+module test;
+endmodule

--- a/tests/generic/class/class_test_52.sv
+++ b/tests/generic/class/class_test_52.sv
@@ -9,3 +9,6 @@ class how_wide #(type DT=int) extends uvm_sequence_item;
   localparam Max_int = {$bits(DT) - 1{1'b1}};
   localparam Min_int = {$bits(int) - $bits(DT){1'b1}};
 endclass
+
+module test;
+endmodule

--- a/tests/generic/class/class_test_53.sv
+++ b/tests/generic/class/class_test_53.sv
@@ -22,3 +22,6 @@ class param_types_as_class_item;
   localparam type GT = mypkg::GlueType, GT2 = int;
   localparam type HT1 = int, HT2 = mypkg::ModuleType#(N+M);
 endclass
+
+module test;
+endmodule

--- a/tests/generic/class/class_test_54.sv
+++ b/tests/generic/class/class_test_54.sv
@@ -8,3 +8,6 @@ class event_calendar;
   event first_date, anniversary;
   event revolution[4:0], independence[2:0];
 endclass
+
+module test;
+endmodule

--- a/tests/generic/class/class_test_55.sv
+++ b/tests/generic/class/class_test_55.sv
@@ -12,3 +12,6 @@ class Driver;
   Packet pNP2 [ *];
   Packet pNP3 [ * ];
 endclass
+
+module test;
+endmodule

--- a/tests/generic/class/class_test_56.sv
+++ b/tests/generic/class/class_test_56.sv
@@ -11,3 +11,6 @@ class Driver;
   data_type_or_module_type foo3, foo4;
   data_type_or_module_type foo5 = 5, foo6 = 6;
 endclass
+
+module test;
+endmodule

--- a/tests/generic/class/class_test_57.sv
+++ b/tests/generic/class/class_test_57.sv
@@ -9,3 +9,6 @@ class fields_with_modifiers;
   const data_type_or_module_type foo1 = 4'hf;
   static data_type_or_module_type foo3, foo4;
 endclass
+
+module test;
+endmodule

--- a/tests/generic/class/class_test_58.sv
+++ b/tests/generic/class/class_test_58.sv
@@ -9,3 +9,6 @@ class fields_with_modifiers;
   const static data_type_or_module_type foo1 = 4'hf;
   static const data_type_or_module_type foo3 = 1, foo4 = 2;
 endclass
+
+module test;
+endmodule

--- a/tests/generic/class/class_test_59.sv
+++ b/tests/generic/class/class_test_59.sv
@@ -7,3 +7,6 @@ class pp_class;
 `ifdef DEBUGGER
 `endif
 endclass
+
+module test;
+endmodule

--- a/tests/generic/class/class_test_6.sv
+++ b/tests/generic/class/class_test_6.sv
@@ -5,3 +5,6 @@
 */
 class Bar; endclass
 class Foo extends Bar; endclass
+
+module test;
+endmodule

--- a/tests/generic/class/class_test_60.sv
+++ b/tests/generic/class/class_test_60.sv
@@ -9,3 +9,6 @@ class pp_class;
 `endif
 `endif
 endclass
+
+module test;
+endmodule

--- a/tests/generic/class/class_test_61.sv
+++ b/tests/generic/class/class_test_61.sv
@@ -7,3 +7,6 @@ class pp_class;
 `ifndef DEBUGGER
 `endif
 endclass
+
+module test;
+endmodule

--- a/tests/generic/class/class_test_62.sv
+++ b/tests/generic/class/class_test_62.sv
@@ -9,3 +9,6 @@ class pp_class;
 `endif
   int router_size;
 endclass
+
+module test;
+endmodule

--- a/tests/generic/class/class_test_63.sv
+++ b/tests/generic/class/class_test_63.sv
@@ -10,3 +10,6 @@ class pp_class;
 `endif
   int router_size;
 endclass
+
+module test;
+endmodule

--- a/tests/generic/class/class_test_64.sv
+++ b/tests/generic/class/class_test_64.sv
@@ -11,3 +11,6 @@ class pp_class;
 `endif
   int router_size;
 endclass
+
+module test;
+endmodule

--- a/tests/generic/class/class_test_65.sv
+++ b/tests/generic/class/class_test_65.sv
@@ -12,3 +12,6 @@ class pp_class;
 `endif
   int router_size;
 endclass
+
+module test;
+endmodule

--- a/tests/generic/class/class_test_66.sv
+++ b/tests/generic/class/class_test_66.sv
@@ -12,3 +12,6 @@ class pp_class;
 `endif
   int router_size;
 endclass
+
+module test;
+endmodule

--- a/tests/generic/class/class_test_67.sv
+++ b/tests/generic/class/class_test_67.sv
@@ -12,3 +12,6 @@ class pp_class;
 `endif
   int router_size;
 endclass
+
+module test;
+endmodule

--- a/tests/generic/class/class_test_68.sv
+++ b/tests/generic/class/class_test_68.sv
@@ -13,3 +13,6 @@ class pp_class;
 `endif
   int router_size;
 endclass
+
+module test;
+endmodule

--- a/tests/generic/class/class_test_69.sv
+++ b/tests/generic/class/class_test_69.sv
@@ -13,3 +13,6 @@ class pp_class;
 `endif
   int router_size;
 endclass
+
+module test;
+endmodule

--- a/tests/generic/class/class_test_7.sv
+++ b/tests/generic/class/class_test_7.sv
@@ -8,3 +8,6 @@ package Package;
 endpackage
 
 class Foo extends Package::Bar; endclass
+
+module test;
+endmodule

--- a/tests/generic/class/class_test_8.sv
+++ b/tests/generic/class/class_test_8.sv
@@ -7,3 +7,6 @@ class Bar #(int X=0, int Y=1, int Z=2); endclass
 localparam x=3, y=4, z=5;
 
 class Foo extends Bar #(x,y,z); endclass
+
+module test;
+endmodule

--- a/tests/generic/class/class_test_9.sv
+++ b/tests/generic/class/class_test_9.sv
@@ -5,3 +5,6 @@
 */
 class Foo #(int N);
 endclass
+
+module test;
+endmodule


### PR DESCRIPTION
Since iverilog does full elaboration it needs to have a top level module so I added a dummy module to all the class tests. This is similar to #1210 from a few weeks ago for the number tests.