### PR TITLE
Use treeless clones for submodules

### DIFF
--- a/.github/add-local-submodule-inner.sh
+++ b/.github/add-local-submodule-inner.sh
@@ -50,12 +50,14 @@ fi
 # If submodule doesn't exist, clone directly from the users repo
 if [ ! -e $SM_PATH/.git ]; then
 	echo "Cloning '$SM_PATH' from repo '$ORIGIN_URL'"
-	git clone $ORIGIN_URL $SM_PATH --origin origin
+	git clone --filter=tree:0 "$ORIGIN_URL" "$SM_PATH" --origin origin
 else
 	(
 		cd $SM_PATH
 		git remote rm origin >/dev/null 2>&1 || true
-		git remote add origin $ORIGIN_URL
+		git remote add origin "$ORIGIN_URL"
+		git config --local remote.origin.promisor true
+		git config --local remote.origin.partialclonefilter 'tree:0'
 	)
 fi
 
@@ -73,7 +75,9 @@ if [ "$USER_URL" != "$ORIGIN_URL" ]; then
 	(
 		cd $SM_PATH
 		git remote rm user >/dev/null 2>&1 || true
-		git remote add user $USER_URL
+		git remote add user "$USER_URL"
+		git config --local remote.user.promisor true
+		git config --local remote.user.partialclonefilter 'tree:0'
 		git fetch user --no-recurse-submodules
 	)
 fi

--- a/.github/workflows/sv-tests-ci.yml
+++ b/.github/workflows/sv-tests-ci.yml
@@ -2,8 +2,6 @@ name: sv-tests-ci
 
 on:
   push:
-    branches:
-      'master'
   pull_request:
 
 jobs:


### PR DESCRIPTION
Using the tips found in https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/ this changes all the submodules to use "treeless" clones.

> * `git clone --filter=tree:0 <url>` creates a treeless clone. These clones download all reachable commits while fetching trees and blobs on-demand. These clones are best for build environments where the repository will be deleted after a single build, but you still need access to commit history.

This makes the amount of data downloaded significantly smaller. This reduces the time taken to clone all the submodules by about a third and helping with https://github.com/SymbiFlow/sv-tests/issues/1241 a bit (30m -> 17m).