### PR TITLE
VeribleExtractor: detect segfaults and ignore redefined macros

### DIFF
--- a/tools/runners/VeribleExtractor.py
+++ b/tools/runners/VeribleExtractor.py
@@ -33,16 +33,28 @@ class VeribleExtractor(BaseRunner):
         inc_dirs = ",".join(params.get("incdirs", []))
 
         with open(script_path, "w") as script:
-            s = (
-                'log="$({executable}'
+            command = (
+                '{executable}'
                 ' --file_list_root ""'
                 ' --include_dir_paths {inc_dirs}'
-                ' --file_list_path {src_list_path}'
-                ' 2>&1 1>/dev/null)"\n'
-                'if [ -n "$log" ]; then echo "$log"; exit 1; fi\n').format(
+                ' --file_list_path {src_list_path}').format(
                     executable=self.executable,
                     inc_dirs=shlex.quote(inc_dirs),
                     src_list_path=shlex.quote(src_list_path))
+            s = (
+                'echo "#" {command_str}\n'
+                'log="$( {command} 2>&1 1>/dev/null )"\n'
+                'rc=$?\n'
+                'echo "stderr:"\n'
+                'echo "$log"\n'
+                'if [ $rc -eq 0 ]; then\n'
+                # Use the log output as an information that something failed.
+                # Ignore warnings about re-defining macros, and empty lines.
+                '    ! echo "$log" | grep -v -e "^I .*] Re-defining macro.*" -e "^$" -q\n'
+                '    rc=$?\n'
+                'fi\n'
+                'exit $rc\n').format(
+                    command_str=shlex.quote(command), command=command)
             script.write(s)
 
         self.cmd = ['sh', script_path]


### PR DESCRIPTION
Two fixes for how results are interpreted:
* Segfaults are reported as failures
* `Re-defining macro` warnings do not cause test failure