### PR TITLE
Change conda channel to litex-hub

### DIFF
--- a/.github/workflows/sv-tests-ci.yml
+++ b/.github/workflows/sv-tests-ci.yml
@@ -42,7 +42,7 @@ jobs:
           - { JOB_NAME: surelog, MAKEFLAGS: -j2 }
           - { JOB_NAME: tree-sitter-verilog, MAKEFLAGS: -j2 }
           - { JOB_NAME: yosys, MAKEFLAGS: -j2 }
-          - { JOB_NAME: antmicro-yosys, MAKEFLAGS: -j2 }
+          - { JOB_NAME: antmicro-yosys-complete, MAKEFLAGS: -j2 }
           - { JOB_NAME: verible, MAKEFLAGS: -j2 }
           - { JOB_NAME: verilator, MAKEFLAGS: -j2 }
           - { JOB_NAME: uhdm-integration-verilator, MAKEFLAGS: -j2 }

--- a/conf/environment.yml
+++ b/conf/environment.yml
@@ -16,11 +16,10 @@ dependencies:
 #  - LiteX-Hub::verible
 #  - LiteX-Hub::verilator
 #  - LiteX-Hub::yosys
-#  - LiteX-Hub::antmicro-yosys
+#  - LiteX-Hub::antmicro-yosys-complete
 #  - LiteX-Hub::zachjs-sv2v
   - ccache
   - python=3.8
   - pip
-  - symbiflow-yosys-plugins
   - pip:                            # Packages installed from PyPI
     - -r file:requirements.txt

--- a/conf/environment.yml
+++ b/conf/environment.yml
@@ -1,23 +1,23 @@
 name: sv-test-env
 channels:
-  - symbiflow
+  - LiteX-Hub
   - pkgw-forge
   - conda-forge
 dependencies:
-#  - symbiflow::iverilog
-#  - symbiflow::moore
-#  - symbiflow::odin_ii
-#  - symbiflow::slang
-#  - symbiflow::surelog
-#  - symbiflow::sv-parser
-#  - symbiflow::tree-sitter-verilog
-#  - symbiflow::uhdm-integration-verilator
-#  - symbiflow::uhdm-integration-yosys
-#  - symbiflow::verible
-#  - symbiflow::verilator
-#  - symbiflow::yosys
-#  - symbiflow::antmicro-yosys
-#  - symbiflow::zachjs-sv2v
+#  - LiteX-Hub::iverilog
+#  - LiteX-Hub::moore
+#  - LiteX-Hub::odin_ii
+#  - LiteX-Hub::slang
+#  - LiteX-Hub::surelog
+#  - LiteX-Hub::sv-parser
+#  - LiteX-Hub::tree-sitter-verilog
+#  - LiteX-Hub::uhdm-integration-verilator
+#  - LiteX-Hub::uhdm-integration-yosys
+#  - LiteX-Hub::verible
+#  - LiteX-Hub::verilator
+#  - LiteX-Hub::yosys
+#  - LiteX-Hub::antmicro-yosys
+#  - LiteX-Hub::zachjs-sv2v
   - ccache
   - python=3.8
   - pip


### PR DESCRIPTION
This PR changes the conda channel from `symbiflow` to `litex-hub`.
This change additionally gives ability to replace `antmicro-yosys` package with `antmicro-yosys-complete` which is a metapackage that contains Antmicro Yosys fork and Yosys plugins.  Then we can remove explicit `symbiflow-yosys-plugins` dependency that forces yosys build on each CI job.