### PR TITLE
Add tests for triggering and waiting for named events

### DIFF
--- a/conf/lrm.conf
+++ b/conf/lrm.conf
@@ -377,6 +377,7 @@ ivtest	Tests imported from ivtest	https://github.com/steveicarus/ivtest
 13.4.4	Background processes spawned by function calls
 14.3	Clocking block declaration
 15.4	Mailboxes
+15.5	Named Events
 16.2	Overview
 16.4	Deferred assertions
 16.7	Sequences

--- a/tests/chapter-15/15.5.1--named-event-trigger-blocking.sv
+++ b/tests/chapter-15/15.5.1--named-event-trigger-blocking.sv
@@ -1,0 +1,36 @@
+/*
+:name: named_event_trigger_blocking
+:description: Trigger named event, blocking
+:tags: 15.5
+:top_module: top
+*/
+
+
+module inner();
+	initial 
+		-> top.e;
+endmodule
+
+module top();
+
+event e;
+
+initial begin
+	// Normal trigger
+	-> e;
+	// Nonblocking trigger
+	->> e; 
+end
+
+endmodule
+
+class foo;
+
+	event e;
+	
+	task wait_e();
+		->e;
+	endtask;
+
+endclass
+

--- a/tests/chapter-15/15.5.1--named-event-trigger-non-blocking.sv
+++ b/tests/chapter-15/15.5.1--named-event-trigger-non-blocking.sv
@@ -1,0 +1,34 @@
+/*
+:name: named_event_trigger_non_blocking
+:description: Trigger named event, non-blocking
+:tags: 15.5
+:top_module: top
+*/
+
+
+module inner();
+	initial 
+		->> top.e;
+endmodule
+
+module top();
+
+event e;
+
+initial begin
+	// Nonblocking trigger
+	->> e; 
+end
+
+endmodule
+
+class foo;
+
+	event e;
+	
+	task wait_e();
+		->> e;
+	endtask;
+
+endclass
+

--- a/tests/chapter-15/15.5.2--named-event-wait.sv
+++ b/tests/chapter-15/15.5.2--named-event-wait.sv
@@ -1,0 +1,35 @@
+/*
+:name: named_event_wait
+:description: Wait for a named event
+:tags: 15.5
+:top_module: top
+*/
+
+
+
+module inner();
+	initial 
+		@top.e;
+endmodule
+
+
+module top();
+
+event e;
+
+initial begin
+	@ e;
+end
+
+endmodule
+
+class foo;
+
+	event e;
+	
+	task wait_e();
+		@e;
+	endtask;
+
+endclass
+


### PR DESCRIPTION
These are described in chapter 15.5 of the LRM.

The tests cover direct and hierachical references to events within
modules, as well as direct references within a class.