### PR TITLE
uhdm-yosys: adapt binary name to newest package

### DIFF
--- a/tools/runners/UhdmYosys.py
+++ b/tools/runners/UhdmYosys.py
@@ -17,7 +17,7 @@ from BaseRunner import BaseRunner
 
 class UhdmYosys(BaseRunner):
     def __init__(self):
-        super().__init__("yosys-uhdm", "yosys-uhdm", {"parsing"})
+        super().__init__("uhdm-yosys", "uhdm-yosys", {"parsing"})
 
         self.url = "https://github.com/alainmarcel/uhdm-integration"
 


### PR DESCRIPTION
Newest PR in ``litex-conda-eda`` changed name of ``uhdm-yosys`` binary: https://github.com/litex-hub/litex-conda-eda/pull/76

This PR adapts UhdmYosys runner to new name.

Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>