### PR TITLE
report-analyzer: kokoro: fix ImportError

### DIFF
--- a/.github/kokoro/run.sh
+++ b/.github/kokoro/run.sh
@@ -90,6 +90,11 @@ echo "----------------------------------------"
 	CHANGES_SUMMARY_JSON=$OUT_DIR"/tests_summary.json"
 	CHANGES_SUMMARY_MD=$OUT_DIR"/tests_summary.md"
 
+	set +x +e
+	source "$HOME/miniconda/etc/profile.d/conda.sh"
+	hash -r
+	conda activate sv-test-env
+
 	# Get base report from sv-tests master run
 	wget https://symbiflow.github.io/sv-tests-results/report.csv -O $BASE_REPORT
 


### PR DESCRIPTION
This PR adds activating conda env in analysis subshell which is needed for fixing `module not found` error in kokoro run: https://source.cloud.google.com/results/invocations/f72adf9f-b967-475c-bf16-889bfd2ab476/targets/foss-fpga-tools%2Fsv-tests%2Fcontinuous/log