### PR TITLE
Fix module path for UhdmYosys tool

### DIFF
--- a/tools/runners/UhdmYosys.py
+++ b/tools/runners/UhdmYosys.py
@@ -35,7 +35,7 @@ class UhdmYosys(BaseRunner):
 
             # prep (without optimizations
             f.write(
-                f"hierarchy -check -top \\work_{top}\n"
+                f"hierarchy -check -top \\{top}\n"
                 "proc\n"
                 "check\n"
                 "memory_dff\n"


### PR DESCRIPTION
The test for ibex core and UhdmYosys tool finishes with the following error:
```ERROR: Module `\work_ibex_core' not found!```
This commit fixes it.

Signed-off-by: Joanna Brozek <jbrozek@antmicro.com>