### PR TITLE
Run CI trigger only on master

### DIFF
--- a/.github/workflows/sv-tests-ci.yml
+++ b/.github/workflows/sv-tests-ci.yml
@@ -2,6 +2,8 @@ name: sv-tests-ci
 
 on:
   push:
+    branches:
+      - master
   pull_request:
 
 jobs:


### PR DESCRIPTION
dependabot creates new branches in the same repo and triggers the CI
twice (for push and for PR).