### PR TITLE
Catch exception thrown by tree-sitter

### DIFF
--- a/tools/runners/tree_sitter_verilog.py
+++ b/tools/runners/tree_sitter_verilog.py
@@ -65,12 +65,17 @@ class tree_sitter_verilog(BaseRunner):
     def run(self, tmp_dir, params):
         self.ret = 0
         self.log = ''
-        lib = self.find_lib()
 
-        lang = Language(lib, 'verilog')
+        try:
+            lib = self.find_lib()
 
-        parser = Parser()
-        parser.set_language(lang)
+            lang = Language(lib, 'verilog')
+
+            parser = Parser()
+            parser.set_language(lang)
+        except Exception as e:
+            self.log += f'{e}\n'
+            self.ret = 1
 
         for src in params['files']:
             f = None


### PR DESCRIPTION
This should work around the issues found in: https://github.com/SymbiFlow/sv-tests/pull/1379/checks?check_run_id=2046877086. Note that this doesn't really fix the runner, it allows the CI to finish despite the updated runner package being broken.