### PR TITLE
Freeze tree-sitter version

### DIFF
--- a/conf/requirements.txt
+++ b/conf/requirements.txt
@@ -1,6 +1,6 @@
 pyyaml
 jinja2
-tree_sitter
+tree_sitter==0.2.2
 pygments
 yapf==0.30.0
 psutil


### PR DESCRIPTION
This does not freeze tree_sitter_verilog, but its dependency.
tree_sitter_verilog seems to be broken with latest tree-sitter, this we
have to freeze its version to make it work again.