### PR TITLE
Fixes for UVM tests

### DIFF
--- a/conf/generators/templates/uvm-classes_2.json
+++ b/conf/generators/templates/uvm-classes_2.json
@@ -11,7 +11,7 @@
 		"import uvm_pkg::*;",
 		"`include \"uvm_macros.svh\"\n",
 
-		"class C extends {0};",
+		"class C extends {0}(\"\", null);",
 		"endclass"
 	],
 	"values": [

--- a/tests/chapter-18/18.13.4--get_randstate_0.sv
+++ b/tests/chapter-18/18.13.4--get_randstate_0.sv
@@ -20,14 +20,14 @@ class env extends uvm_env;
   function new(string name, uvm_component parent = null);
     super.new(name, parent);
   endfunction
-  
+
   task run_phase(uvm_phase phase);
     phase.raise_objection(this);
     begin
       ret = obj.randomize();
       randstate = obj.get_randstate();
 
-      if(ret == 1 && randstate != null) begin
+      if(ret == 1 && randstate != "") begin
         `uvm_info("RESULT", $sformatf("ret = %0d randstate = %s SUCCESS", ret, randstate), UVM_LOW);
       end else begin
         `uvm_error("RESULT", $sformatf("ret = %0d randstate = %s FAILED", ret, randstate));
@@ -35,7 +35,7 @@ class env extends uvm_env;
     end
     phase.drop_objection(this);
   endtask: run_phase
-  
+
 endclass
 
 module top;
@@ -46,5 +46,5 @@ module top;
     environment = new("env");
     run_test();
   end
-  
+
 endmodule

--- a/tests/chapter-18/18.5.11--static-constraint-blocks_1.sv
+++ b/tests/chapter-18/18.5.11--static-constraint-blocks_1.sv
@@ -19,13 +19,12 @@ class env extends uvm_env;
   a obj1 = new;
   a obj2 = new;
 
-  /* shall affect all instances of constraint c2 */
-  obj1.c1.constraint_mode(0);
-
   function new(string name, uvm_component parent = null);
     super.new(name, parent);
+    /* shall affect all instances of constraint c2 */
+    obj1.c1.constraint_mode(0);
   endfunction
-  
+
   task run_phase(uvm_phase phase);
     phase.raise_objection(this);
     begin
@@ -39,7 +38,7 @@ class env extends uvm_env;
     end
     phase.drop_objection(this);
   endtask: run_phase
-  
+
 endclass
 
 module top;
@@ -50,5 +49,5 @@ module top;
     environment = new("env");
     run_test();
   end
-  
+
 endmodule


### PR DESCRIPTION
Fixed a few issues in various UVM tests:
1. strings are not comparable to null, so changed to empty string
2. One test was trying to make a function call statement in the middle of a class body which is invalid
3. The generated uvm_classes_2 tests were not providing parameters to the super class constructor

Signed-off-by: MikePopoloski <mike@popoloski.com>