### PR TITLE
Don't run PR commenter on master

### DIFF
--- a/.github/workflows/comment-pr.yml
+++ b/.github/workflows/comment-pr.yml
@@ -12,7 +12,8 @@ jobs:
     runs-on: ubuntu-18.04
     if: >
       ${{ github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion == 'success' }}
+          github.event.workflow_run.conclusion == 'success' &&
+          github.ref != 'refs/heads/master' }}
     steps:
       - name: Prepare output directories
         run: mkdir -p out/report


### PR DESCRIPTION
The workflow for the commenter is started not only in pull requests, but also after the PR is merged, e.g: https://github.com/SymbiFlow/sv-tests/actions/runs/729723318

This PR is an attempt to stop that.