### PR TITLE
Add -sverilog to Surelog cmd for black-parrot test

### DIFF
--- a/tools/runners/Surelog.py
+++ b/tools/runners/Surelog.py
@@ -22,6 +22,8 @@ class Surelog(BaseRunner):
         self.cmd = [
             self.executable, '-nopython', '-nobuiltin', '-parse', '-noelab'
         ]
+        if "black-parrot" in params["tags"]:
+            self.cmd.append('-sverilog')
 
         for incdir in params['incdirs']:
             self.cmd.append('-I' + incdir)


### PR DESCRIPTION
This PR is adding -sverilog flag to Surelog for black-parrot tests. Reported in: https://github.com/SymbiFlow/sv-tests/issues/1438

Signed-off-by: Paweł Czarnecki <pczarnecki@antmicro.com>