### PR TITLE
slang runner: Set --parse-only for certain test groups

### DIFF
--- a/tools/runners/Slang.py
+++ b/tools/runners/Slang.py
@@ -38,6 +38,16 @@ class Slang(BaseRunner):
         for define in params['defines']:
             self.cmd.extend(['-D', define])
 
+        # hdlconv tests are not semantically valid SystemVerilog, so we
+        # can only expect to run parsing successfully.
+        tags = params["tags"]
+        if "hdlconv" in tags or "hdlconv_std2012" in tags or "hdlconv_std2017" in tags:
+            self.cmd.append('--parse-only')
+
+        # utd tests reference unknown modules, so we can't do real elaboration on them
+        if "utd-sv" in tags:
+        	self.cmd.append('--lint-only')
+
         self.cmd += params['files']
 
     def get_version(self):

--- a/tools/runners/Slang.py
+++ b/tools/runners/Slang.py
@@ -38,15 +38,11 @@ class Slang(BaseRunner):
         for define in params['defines']:
             self.cmd.extend(['-D', define])
 
-        # hdlconv tests are not semantically valid SystemVerilog, so we
+        # hdlconv and utd tests are not semantically valid SystemVerilog, so we
         # can only expect to run parsing successfully.
         tags = params["tags"]
-        if "hdlconv" in tags or "hdlconv_std2012" in tags or "hdlconv_std2017" in tags:
+        if "hdlconv" in tags or "hdlconv_std2012" in tags or "hdlconv_std2017" in tags or "utd-sv" in tags:
             self.cmd.append('--parse-only')
-
-        # utd tests reference unknown modules, so we can't do real elaboration on them
-        if "utd-sv" in tags:
-        	self.cmd.append('--lint-only')
 
         self.cmd += params['files']
 


### PR DESCRIPTION
Some of the imported test groups are not semantically valid SystemVerilog, so set flags in the slang runner to only do parsing.