### PR TITLE
Blacklist a few broken tests from hdlconv and utd

### DIFF
--- a/conf/generators/meta-path/hdlconvertor.json
+++ b/conf/generators/meta-path/hdlconvertor.json
@@ -7,8 +7,10 @@
 	],
 	"matches": ["*.sv", "*.v"],
 	"blacklist": [
+		"aes.v",
 		"adder_implicit.sv",
 		"directive_verilogpp.sv",
-		"fifo_rx.sv"
+		"fifo_rx.sv",
+		"parity_using_function2.v"
 	]
 }

--- a/conf/generators/meta-path/utd-systemverilog.json
+++ b/conf/generators/meta-path/utd-systemverilog.json
@@ -5,5 +5,5 @@
 		["tests", "utd-sv"]
 	],
 	"matches": ["*.v"],
-	"blacklist": ["sparc_ffu_ctl_visctl.v", "operators.v", "pad_jbusl.v", "pad_jbusr.v", "fpu_in_ctl.v"]
+	"blacklist": ["sparc_ffu_ctl_visctl.v", "operators.v", "pad_jbusl.v", "pad_jbusr.v", "fpu_in_ctl.v", "ifdef-2.v"]
 }


### PR DESCRIPTION
The two hdlconv tests use `wire` as a function return type which is not allowed and doesn't make much sense anyway (wire is not a data type, it's a net type).

The utd test is just lexically broken, it's missing a closing quote on one of its strings.