### PR TITLE
Remove debug logs in PR commenter

### DIFF
--- a/.github/workflows/comment-pr.yml
+++ b/.github/workflows/comment-pr.yml
@@ -12,11 +12,6 @@ jobs:
     runs-on: ubuntu-18.04
     if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - name: test
-        run: |
-          echo ${{ github.event.workflow_run.event }}
-          echo ${{ github.event.workflow_run.conclusion }}
-          echo ${{ github.event.workflow_run.ref }}
       - name: Prepare output directories
         run: mkdir -p out/report
 


### PR DESCRIPTION
They served their purpose. The previous PRs fixed the checks, the log
messages can be removed now.

Signed-off-by: Tomasz Gorochowik <tgorochowik@antmicro.com>