### PR TITLE
Allow build cores without `-noelab` argument for Surelog tool

### DIFF
--- a/conf/fusesoc-configs/earlgrey.yml
+++ b/conf/fusesoc-configs/earlgrey.yml
@@ -8,3 +8,4 @@ conf_file: build/lowrisc_systems_top_earlgrey_0.1/sim-icarus/lowrisc_systems_top
 test_file: earlgrey.sv
 timeout: 360
 compatible-runners: all
+allow_elaboration: True

--- a/conf/fusesoc-configs/ibex-sim.yml
+++ b/conf/fusesoc-configs/ibex-sim.yml
@@ -8,3 +8,4 @@ conf_file: build/lowrisc_ibex_ibex_simple_system_0/sim-verilator/lowrisc_ibex_ib
 test_file: ibex-sim.sv
 timeout: 100
 compatible-runners: verilator-uhdm verilator
+allow_elaboration: True

--- a/conf/fusesoc-configs/ibex-synth.yml
+++ b/conf/fusesoc-configs/ibex-synth.yml
@@ -8,3 +8,4 @@ conf_file: build/lowrisc_ibex_top_artya7_0.1/synth-vivado/lowrisc_ibex_top_artya
 test_file: ibex-synth.sv
 timeout: 100
 compatible-runners: uhdm-yosys yosys yosys-sv zachjs-sv2v icarus moore moore-parse odin slang sv-parser tree-sitter-verilog verible verible_extractor Surelog
+allow_elaboration: True

--- a/conf/fusesoc-configs/swerv.yml
+++ b/conf/fusesoc-configs/swerv.yml
@@ -8,3 +8,4 @@ conf_file: build/chipsalliance.org_cores_SweRV_EH1_1.8/lint-verilator/chipsallia
 test_file: swerv.sv
 timeout: 180
 compatible-runners: all
+allow_elaboration: True

--- a/generators/fusesoc
+++ b/generators/fusesoc
@@ -14,6 +14,7 @@ templ = """/*
 :tags: {5}
 :timeout: {6}
 :compatible-runners: {7}
+:allow_elaboration: {8}
 */
 """
 
@@ -59,6 +60,7 @@ for fusesoc_conf_file in fusesoc_conf_files:
         yml_conf["test_file"]
         yml_conf["timeout"]
         yml_conf["compatible-runners"]
+        yml_conf["allow_elaboration"]
     except KeyError as err:
         print("No key", err, "in file", fusesoc_conf_file)
         continue
@@ -123,4 +125,4 @@ for fusesoc_conf_file in fusesoc_conf_files:
             templ.format(
                 yml_conf["name"], yml_conf["description"], sources, incdirs,
                 top_module, yml_conf["tags"], yml_conf["timeout"],
-                yml_conf["compatible-runners"]))
+                yml_conf["compatible-runners"], yml_conf["allow_elaboration"]))

--- a/generators/fusesoc
+++ b/generators/fusesoc
@@ -115,20 +115,12 @@ for fusesoc_conf_file in fusesoc_conf_files:
         sys.exit(1)
 
     # Fusesoc files dedicated for Verilator contains top module
-    if core_conf_path.endswith('.vc'):
+    if not core_conf_path.endswith('.vc'):
+        top_module = yml_conf["top_module"]
 
-        with open(test_file, "w") as f:
-            f.write(
-                templ.format(
-                    yml_conf["name"], yml_conf["description"], sources,
-                    incdirs, top_module, yml_conf["tags"], yml_conf["timeout"],
-                    yml_conf["compatible-runners"]))
-
-    else:
-
-        with open(test_file, "w") as f:
-            f.write(
-                templ.format(
-                    yml_conf["name"], yml_conf["description"], sources,
-                    incdirs, yml_conf["top_module"], yml_conf["tags"],
-                    yml_conf["timeout"], yml_conf["compatible-runners"]))
+    with open(test_file, "w") as f:
+        f.write(
+            templ.format(
+                yml_conf["name"], yml_conf["description"], sources, incdirs,
+                top_module, yml_conf["tags"], yml_conf["timeout"],
+                yml_conf["compatible-runners"]))

--- a/tools/runner
+++ b/tools/runner
@@ -113,7 +113,7 @@ test = os.path.abspath(os.path.join(dirs['tests'], args.test))
 supported_test_params = [
     "name", "tags", "description", "files", "incdirs", "top_module", "timeout",
     "type", "should_fail", "should_fail_because", "defines",
-    "compatible-runners"
+    "compatible-runners", "allow_elaboration"
 ]
 
 test_params = {}
@@ -157,6 +157,7 @@ try:
             test_params.setdefault('should_fail_because', "")
             test_params.setdefault('defines', "")
             test_params.setdefault('compatible-runners', "all")
+            test_params.setdefault('allow_elaboration', "False")
 
             if len(set(supported_test_params) - set(test_params.keys())) != 0:
                 missing = list(

--- a/tools/runners/Surelog.py
+++ b/tools/runners/Surelog.py
@@ -10,6 +10,7 @@
 # SPDX-License-Identifier: ISC
 
 from BaseRunner import BaseRunner
+from distutils.util import strtobool
 
 
 class Surelog(BaseRunner):
@@ -19,9 +20,11 @@ class Surelog(BaseRunner):
         self.url = "https://github.com/alainmarcel/Surelog"
 
     def prepare_run_cb(self, tmp_dir, params):
-        self.cmd = [
-            self.executable, '-nopython', '-nobuiltin', '-parse', '-noelab'
-        ]
+        self.cmd = [self.executable, '-nopython', '-nobuiltin', '-parse']
+
+        if not strtobool(params['allow_elaboration']):
+            self.cmd.append('-noelab')
+
         if "black-parrot" in params["tags"]:
             self.cmd.append('-sverilog')
 

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -313,7 +313,8 @@ def collect_logs(runner_name):
             "description", "files", "incdirs", "top_module", "runner",
             "runner_url", "time_elapsed", "type", "mode", "timeout",
             "user_time", "system_time", "ram_usage", "tool_success",
-            "should_fail_because", "defines", "compatible-runners"
+            "should_fail_because", "defines", "compatible-runners",
+            "allow_elaboration"
         ]
         with open(t, "r") as f:
             try:


### PR DESCRIPTION
Add the possibility to build cores without  `-noelab` argument for Surelog tool.