### PR TITLE
Blacklist broken yosys tests

### DIFF
--- a/conf/generators/meta-path/yosys-memories.json
+++ b/conf/generators/meta-path/yosys-memories.json
@@ -4,5 +4,6 @@
 	"paths": [
 		["tools", "yosys", "tests", "memories"]
 	],
-	"matches": ["*.v"]
+	"matches": ["*.v"],
+	"blacklist": ["issue00335.v"]
 }

--- a/conf/generators/meta-path/yosys-simple.json
+++ b/conf/generators/meta-path/yosys-simple.json
@@ -5,5 +5,5 @@
 		["tools", "yosys", "tests", "simple"]
 	],
 	"matches": ["*.v"],
-	"blacklist": ["hierdefparam.v", "memory.v", "values.v"]
+	"blacklist": ["hierdefparam.v", "memory.v", "values.v", "func_width_scope.v", "named_genblk.v"]
 }

--- a/conf/generators/meta-path/yosys-sva.json
+++ b/conf/generators/meta-path/yosys-sva.json
@@ -4,5 +4,6 @@
 	"paths": [
 		["tools", "yosys", "tests", "sva"]
 	],
-	"matches": ["*.sv"]
+	"matches": ["*.sv"],
+	"blacklist": ["basic04.sv", "basic05.sv"]
 }

--- a/conf/generators/meta-path/yosys-svinterfaces.json
+++ b/conf/generators/meta-path/yosys-svinterfaces.json
@@ -4,5 +4,6 @@
 	"paths": [
 		["tools", "yosys", "tests", "svinterfaces"]
 	],
-	"matches": ["*.sv"]
+	"matches": ["*.sv"],
+	"blacklist": ["svinterface1.sv", "svinterface_at_top.sv"]
 }

--- a/generators/yosys_hana
+++ b/generators/yosys_hana
@@ -44,6 +44,10 @@ if not os.path.isdir(test_dir):
     os.makedirs(test_dir, exist_ok=True)
 
 for f in glob.glob(os.path.join(yosys_path, 'tests', 'hana', 'test*.v')):
+    # test_parser has invalid syntax
+    if 'test_parser.v' in f:
+        continue
+
     fname = 'hana_' + os.path.basename(os.path.splitext(f)[0])
     test_file = os.path.join(test_dir, fname + '.sv')
 


### PR DESCRIPTION
Blacklisting tests because:
* The hana "test_parser" test has messed up syntax around a macro expansion; it seems like the test is assuming the tokens will automatically concatenate with each other. No commercial tool I tried can parse this and the LRM does not seem to allow it either.
* memories_issue00335 references a parameter before it's declared
* simple_func_width_scope uses a function declared inside a generate block in a constant expression. This is directly disallowed by the LRM.
* simple_named_genblk references an unnamed generate block by name which is not allowed (and makes no sense anyway).
* sva_basic04 tries to bind a module to a "top" instance even though there is no such instance.
* sva_basic05 tries to instantiate a module called "demo" even though there is no such module.
* svinterface1 and svinterface_at_top both pass the wrong modport to an interface port, which is disallowed.