### PR TITLE
Fix basejump STL test setup

### DIFF
--- a/conf/generators/meta-path/basejump.json
+++ b/conf/generators/meta-path/basejump.json
@@ -8,11 +8,18 @@
 	"commons": [
 		"cores/basejump_stl/bsg_misc/bsg_defines.v",
 		"cores/basejump_stl/bsg_cache/bsg_cache_pkg.v",
-		"cores/basejump_stl/bsg_cache/bsg_cache_non_blocking_pkg.v"
+		"cores/basejump_stl/bsg_cache/bsg_cache_non_blocking_pkg.v",
+		"cores/basejump_stl/bsg_dmc/bsg_dmc_pkg.v",
+		"cores/basejump_stl/bsg_noc/bsg_noc_pkg.v",
+		"cores/basejump_stl/bsg_noc/bsg_mesh_router_pkg.v",
+		"cores/basejump_stl/bsg_noc/bsg_wormhole_router_pkg.v",
+		"cores/basejump_stl/bsg_tag/bsg_tag_pkg.v",
+		"cores/basejump_stl/bsg_test/bsg_dramsim3_pkg.v"
 	],
 	"incdirs": [
 		"cores/basejump_stl/bsg_misc",
-		"cores/basejump_stl/bsg_noc"
+		"cores/basejump_stl/bsg_noc",
+		"cores/basejump_stl/bsg_clk_gen"
 	],
 	"timeouts": {
 		"bsg_scatter_gather.v": "60",
@@ -24,7 +31,14 @@
 	},
 	"blacklist": [
 		"bsg_nonsynth_mixin_motherboard.v",
-		"test_bsg_clock_params.v"
+		"test_bsg_clock_params.v",
+		"bsg_cache_pkg.v",
+		"bsg_cache_non_blocking_pkg.v",
+		"bsg_dmc_pkg.v",
+		"bsg_dramsim3_pkg.v",
+		"bsg_mesh_router_pkg.v",
+		"bsg_tag_pkg.v",
+		"bsg_wormhole_router_pkg.v"
 	],
 	"fake_topmodule": true
 }


### PR DESCRIPTION
* Add various missing package references
* Add missing include directory
* Blacklist the package files, since otherwise the package tests will include the packages multiple times causing errors