### PR TITLE
Change url for ibex-yosys-build submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -75,7 +75,7 @@
 	url = https://github.com/alainmarcel/uhdm-integration.git
 [submodule "third_party/cores/ibex-yosys-build"]
 	path = third_party/cores/ibex-yosys-build
-	url = https://github.com/antmicro/ibex-yosys-build
+	url = https://github.com/SymbiFlow/ibex-yosys-build.git
 [submodule "third_party/tools/antmicro-yosys"]
 	path = third_party/tools/antmicro-yosys
 	url = https://github.com/antmicro/yosys


### PR DESCRIPTION
Don't use a repository fork.

Signed-off-by: Joanna Brozek <jbrozek@antmicro.com>