### PR TITLE
Change verilator-uhdm and yosys-uhdm package names

### DIFF
--- a/.github/workflows/sv-tests-ci.yml
+++ b/.github/workflows/sv-tests-ci.yml
@@ -47,8 +47,8 @@ jobs:
           - { JOB_NAME: antmicro-yosys-complete, MAKEFLAGS: -j2 }
           - { JOB_NAME: verible, MAKEFLAGS: -j2 }
           - { JOB_NAME: verilator, MAKEFLAGS: -j2 }
-          - { JOB_NAME: uhdm-integration-verilator, MAKEFLAGS: -j2 RUNNERS_FILTER=UhdmVerilator }
-          - { JOB_NAME: uhdm-integration-yosys, MAKEFLAGS: -j2 RUNNERS_FILTER=UhdmYosys }
+          - { JOB_NAME: verilator-uhdm, MAKEFLAGS: -j2 RUNNERS_FILTER=UhdmVerilator }
+          - { JOB_NAME: yosys-uhdm, MAKEFLAGS: -j2 RUNNERS_FILTER=UhdmYosys }
           - { JOB_NAME: zachjs-sv2v, MAKEFLAGS: -j2 }
 
     name: ${{ matrix.env.JOB_NAME }}

--- a/conf/environment.yml
+++ b/conf/environment.yml
@@ -11,8 +11,8 @@ dependencies:
 #  - LiteX-Hub::surelog
 #  - LiteX-Hub::sv-parser
 #  - LiteX-Hub::tree-sitter-verilog
-#  - LiteX-Hub::uhdm-integration-verilator
-#  - LiteX-Hub::uhdm-integration-yosys
+#  - LiteX-Hub::verilator-uhdm
+#  - LiteX-Hub::yosys-uhdm
 #  - LiteX-Hub::verible
 #  - LiteX-Hub::verilator
 #  - LiteX-Hub::yosys

--- a/tools/runners/UhdmVerilator.py
+++ b/tools/runners/UhdmVerilator.py
@@ -35,7 +35,7 @@ class UhdmVerilator(BaseRunner):
             f.write("set -e\n")
             f.write('set -x\n')
             f.write(
-                'surelog-uhdm -nopython -nobuiltin --disable-feature=parametersubstitution -parse -sverilog'
+                'surelog -nopython -nobuiltin --disable-feature=parametersubstitution -parse -sverilog'
             )
             for i in params['incdirs']:
                 f.write(f' -I{i}')

--- a/tools/runners/UhdmYosys.py
+++ b/tools/runners/UhdmYosys.py
@@ -72,7 +72,7 @@ class UhdmYosys(BaseRunner):
             f.write("set -e\n")
             f.write("set -x\n")
             f.write(
-                f"surelog-uhdm -nopython -nobuiltin --disable-feature=parametersubstitution -parse -sverilog {library_paths}"
+                f"surelog -nopython -nobuiltin --disable-feature=parametersubstitution -parse -sverilog {library_paths}"
             )
             for i in params["incdirs"]:
                 f.write(f" -I{i}")


### PR DESCRIPTION
``uhdm-integration-*`` packages were removed in PR: https://github.com/hdl/conda-eda/pull/106 as this packages were shipped with different version of ``surelog`` then version that was used to built ``yosys``/``verilator``.

Now ``surelog`` is part of ``yosys-uhdm``/``verilator-uhdm`` packages. 
This PR changes used package name and adapts rest of the scripts. This should solve random ``segmentation faults`` caused by incompatible versions of ``surelog`` used to generate UHDM file with version used to compile tool.

Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>