### PR TITLE
Fix broken clocking block tests

### DIFF
--- a/tests/chapter-14/14.3--clocking-block-signals.sv
+++ b/tests/chapter-14/14.3--clocking-block-signals.sv
@@ -14,11 +14,6 @@
 */
 module top(input clk, input a, output b, output c);
 
-wire clk;
-wire a;
-wire b;
-wire c;
-
 clocking ck1 @(posedge clk);
 	default input #10ns output #5ns;
 	input a;

--- a/tests/chapter-14/14.3--clocking-block.sv
+++ b/tests/chapter-14/14.3--clocking-block.sv
@@ -14,8 +14,6 @@
 */
 module top(input clk);
 
-wire clk;
-
 clocking ck1 @(posedge clk);
 	default input #10ns output #5ns;
 endclocking

--- a/tests/chapter-14/14.3--default-clocking-block.sv
+++ b/tests/chapter-14/14.3--default-clocking-block.sv
@@ -14,8 +14,6 @@
 */
 module top(input clk);
 
-wire clk;
-
 default clocking @(posedge clk);
 	default input #10ns output #5ns;
 endclocking

--- a/tests/chapter-14/14.3--global-clocking-block.sv
+++ b/tests/chapter-14/14.3--global-clocking-block.sv
@@ -14,8 +14,6 @@
 */
 module top(input clk);
 
-wire clk;
-
 global clocking ck1 @(posedge clk); endclocking
 
 endmodule


### PR DESCRIPTION
These tests declared local variables with names that collide with module port names.
```
../../src/github/sv-tests/tests/chapter-14/14.3--clocking-block.sv:15:18: error: redefinition of 'clk'
module top(input clk);
                 ^
../../src/github/sv-tests/tests/chapter-14/14.3--clocking-block.sv:17:6: note: previous definition here
wire clk;
     ^
```