### PR TITLE
Fix ibex test

### DIFF
--- a/conf/fusesoc-configs/ibex-sim.yml
+++ b/conf/fusesoc-configs/ibex-sim.yml
@@ -16,5 +16,5 @@ command: fusesoc --cores-root third_party/cores/ibex run --target=sim --setup lo
 conf_file: build/lowrisc_ibex_ibex_simple_system_0/sim-verilator/lowrisc_ibex_ibex_simple_system_0.vc
 test_file: ibex-sim.sv
 timeout: 100
-compatible-runners: verilator-uhdm verilator
+compatible-runners: verilator-uhdm verilator slang
 allow_elaboration: True

--- a/conf/fusesoc-configs/ibex-synth.yml
+++ b/conf/fusesoc-configs/ibex-synth.yml
@@ -16,5 +16,5 @@ command: fusesoc --cores-root third_party/cores/ibex run --target=synth --setup 
 conf_file: build/lowrisc_ibex_top_artya7_0.1/synth-vivado/lowrisc_ibex_top_artya7_0.1.tcl
 test_file: ibex-synth.sv
 timeout: 100
-compatible-runners: uhdm-yosys yosys yosys-sv zachjs-sv2v icarus moore moore-parse odin slang sv-parser tree-sitter-verilog verible verible_extractor Surelog
+compatible-runners: uhdm-yosys yosys yosys-sv zachjs-sv2v icarus moore moore-parse odin sv-parser tree-sitter-verilog verible verible_extractor Surelog
 allow_elaboration: True

--- a/generators/fusesoc
+++ b/generators/fusesoc
@@ -10,11 +10,12 @@ templ = """/*
 :description: {1}
 :files: {2}
 :incdirs: {3}
-:top_module: {4}
-:tags: {5}
-:timeout: {6}
-:compatible-runners: {7}
-:allow_elaboration: {8}
+:defines: {4}
+:top_module: {5}
+:tags: {6}
+:timeout: {7}
+:compatible-runners: {8}
+:allow_elaboration: {9}
 */
 """
 
@@ -82,6 +83,7 @@ for fusesoc_conf_file in fusesoc_conf_files:
 
     incdirs = ''
     sources = ''
+    defines = ''
 
     if core_conf_path.endswith(".vc") or core_conf_path.endswith(".scr"):
         with open(core_conf_path, "r") as f:
@@ -94,6 +96,8 @@ for fusesoc_conf_file in fusesoc_conf_files:
                 elif (core_conf_path.endswith('.vc')
                       and line.startswith("--top-module")):
                     top_module = line.partition("--top-module ")[2]
+                elif line.startswith("-D"):
+                    defines += line[2:] + ' '
                 elif not line.startswith("-") and line:
                     sources += os.path.join(sources_path, line) + ' '
     elif core_conf_path.endswith(".tcl"):
@@ -124,5 +128,5 @@ for fusesoc_conf_file in fusesoc_conf_files:
         f.write(
             templ.format(
                 yml_conf["name"], yml_conf["description"], sources, incdirs,
-                top_module, yml_conf["tags"], yml_conf["timeout"],
+                defines, top_module, yml_conf["tags"], yml_conf["timeout"],
                 yml_conf["compatible-runners"], yml_conf["allow_elaboration"]))

--- a/tools/BaseRunner.py
+++ b/tools/BaseRunner.py
@@ -59,6 +59,7 @@ class BaseRunner:
         self.name = name
         self.executable = executable
         self.supported_features = supported_features
+        self.allowed_extensions = ['.v', '.sv', '.vh', '.svh']
 
         self.url = "https://github.com/symbiflow/sv-tests"
 

--- a/tools/runner
+++ b/tools/runner
@@ -209,6 +209,11 @@ for key in libs.keys():
 
 test_params['defines'] = test_params['defines'].split()
 
+# Some tests have *.vlt and *.cc files which are specific to verilator,
+# so filter them out for all other runners.
+if 'verilator' not in args.runner:
+    test_params['files'] = [f for f in test_params['files'] if not f.endswith('.vlt') and not f.endswith('.cc')] 
+
 try:
     tmp_dir = tempfile.mkdtemp()
 except (PermissionError, FileExistsError) as e:

--- a/tools/runner
+++ b/tools/runner
@@ -209,13 +209,11 @@ for key in libs.keys():
 
 test_params['defines'] = test_params['defines'].split()
 
-# Some tests have *.vlt and *.cc files which are specific to verilator,
-# so filter them out for all other runners.
-if 'verilator' not in args.runner:
-    test_params['files'] = [
-        f for f in test_params['files']
-        if not f.endswith('.vlt') and not f.endswith('.cc')
-    ]
+# Filter test files based on what the runner claims to support.
+test_params['files'] = [
+    f for f in test_params['files']
+    if os.path.splitext(f)[1] in runner_obj.allowed_extensions
+]
 
 try:
     tmp_dir = tempfile.mkdtemp()

--- a/tools/runner
+++ b/tools/runner
@@ -210,10 +210,16 @@ for key in libs.keys():
 test_params['defines'] = test_params['defines'].split()
 
 # Filter test files based on what the runner claims to support.
-test_params['files'] = [
-    f for f in test_params['files']
-    if os.path.splitext(f)[1] in runner_obj.allowed_extensions
-]
+filtered_files = []
+for f in test_params['files']:
+    if os.path.splitext(f)[1] in runner_obj.allowed_extensions:
+        filtered_files.append(f)
+    else:
+        logger.info(
+            "Skipping '{}' with '{}' due to unsupported extension".format(
+                f, args.runner))
+
+test_params['files'] = filtered_files
 
 try:
     tmp_dir = tempfile.mkdtemp()

--- a/tools/runner
+++ b/tools/runner
@@ -212,7 +212,10 @@ test_params['defines'] = test_params['defines'].split()
 # Some tests have *.vlt and *.cc files which are specific to verilator,
 # so filter them out for all other runners.
 if 'verilator' not in args.runner:
-    test_params['files'] = [f for f in test_params['files'] if not f.endswith('.vlt') and not f.endswith('.cc')] 
+    test_params['files'] = [
+        f for f in test_params['files']
+        if not f.endswith('.vlt') and not f.endswith('.cc')
+    ]
 
 try:
     tmp_dir = tempfile.mkdtemp()

--- a/tools/runners/UhdmVerilator.py
+++ b/tools/runners/UhdmVerilator.py
@@ -19,6 +19,7 @@ class UhdmVerilator(BaseRunner):
     def __init__(self):
         super().__init__("verilator-uhdm", "verilator-uhdm")
 
+        self.allowed_extensions.extend(['.vlt', '.cc'])
         self.url = "https://github.com/alainmarcel/uhdm-integration"
 
     def prepare_run_cb(self, tmp_dir, params):

--- a/tools/runners/Verilator.py
+++ b/tools/runners/Verilator.py
@@ -19,6 +19,7 @@ class Verilator(BaseRunner):
     def __init__(self):
         super().__init__("verilator", "verilator")
 
+        self.allowed_extensions.extend(['.vlt', '.cc'])
         self.url = "https://verilator.org"
 
     def prepare_run_cb(self, tmp_dir, params):


### PR DESCRIPTION
This makes it possible for simulation tools to build the Ibex core (and changes slang to not use the synthesis target).
- vlt and cc files need to be filtered out for all non-verilator tools
- Even Verilator couldn't build the Ibex core because the fusesoc generator wasn't including the necessary defines