### PR TITLE
Fix clocking block test, add a should_fail test to mirror

### DIFF
--- a/tests/chapter-14/14.3--clocking-block-signals-error.sv
+++ b/tests/chapter-14/14.3--clocking-block-signals-error.sv
@@ -10,9 +10,11 @@
 /*
 :name: clocking_block_signals
 :description: clocking block with signals test
+:should_fail_because: assigning to net from procedural context
+:type: simulation
 :tags: 14.3
 */
-module top(input clk, input a, output logic b, output logic c);
+module top(input clk, input a, output b, output c);
 
 clocking ck1 @(posedge clk);
 	default input #10ns output #5ns;


### PR DESCRIPTION
One of the clocking block tests was invalid because it tried to assign to nets from within a procedural context. This diff adds a should_fail to that test and adds a new duplicated test with the original error fixed.