### PR TITLE
minor ui fix

### DIFF
--- a/conf/report/report.css
+++ b/conf/report/report.css
@@ -87,6 +87,7 @@ table.dataTable tfoot th {
   overflow: hidden;
   width: 30em;
   max-width: 30em;
+  min-width: 30em;
 }
 
 .tag_link, .tool_link {


### PR DESCRIPTION
Signed-off-by: Prahitha Movva <prahitha.movva03@gmail.com>
When using search, the width/position of the first column is not consistent. This PR fixes the issue by making the width of the first column 30em always.

Previously (when the first column is not long/wide enough):
![Screenshot (33)](https://user-images.githubusercontent.com/44160152/120062410-d1501c80-c07f-11eb-9fcd-762d09cdd157.png)
