### PR TITLE
Fix Ariane core build

### DIFF
--- a/generators/ariane
+++ b/generators/ariane
@@ -69,7 +69,12 @@ for components in ver_cmd_comp:
         top_module = args
         get_top_module = False
     elif args.endswith('.sv'):
-        sources += os.path.join(ariane_path, args) + ' '
+        # The Ariane file lists contains a reference to this file but the module itself
+        # isn't instantiated anywhere. Problematically, it contains references to a
+        # nonexistent interface, so it otherwise breaks elaboration. This hack can be
+        # removed if the problem gets fixed upstream.
+        if 'axi2apb_wrap.sv' not in args:
+            sources += os.path.join(ariane_path, args) + ' '
 
 os.chdir(main_path)
 test_dir = os.path.join(tests_dir, 'generated', tests_subdir)

--- a/tools/runners/Slang.py
+++ b/tools/runners/Slang.py
@@ -44,6 +44,11 @@ class Slang(BaseRunner):
         if "hdlconv" in tags or "hdlconv_std2012" in tags or "hdlconv_std2017" in tags or "utd-sv" in tags:
             self.cmd.append('--parse-only')
 
+        # The Ariane core does not build correctly if VERILATOR is not defined -- it will attempt
+        # to reference nonexistent modules, for example.
+        if "ariane" in tags:
+            self.cmd.append("-DVERILATOR")
+
         self.cmd += params['files']
 
     def get_version(self):


### PR DESCRIPTION
This fixes the Ariane build for the slang runner. Two problems fixed:
1. The Ariane target we're using doesn't build if you don't define VERILATOR, since it otherwise references nonexistent modules.
2. The filelist includes "axi2apb_wrap.sv" which tries to use nonexistent interfaces. axi2apb_wrap is never used anywhere itself so it's fine to just remove it.