### PR TITLE
Fix black-parrot test file lists

### DIFF
--- a/generators/black-parrot
+++ b/generators/black-parrot
@@ -58,23 +58,23 @@ lists = [
     {
         'name': 'bp_fe',
         'top': 'bp_fe_top',
-        'flist': 'bp_fe/syn/flist.vcs'
+        'flist': 'bp_top/syn/flist.vcs'
     }, {
         'name': 'bp_be',
         'top': 'bp_be_top',
-        'flist': 'bp_be/syn/flist.vcs'
+        'flist': 'bp_top/syn/flist.vcs'
     }, {
         'name': 'bp_cce',
         'top': 'bp_cce',
-        'flist': 'bp_me/syn/flist.vcs'
+        'flist': 'bp_top/syn/flist.vcs'
     }, {
         'name': 'bp_lce',
         'top': 'bp_lce',
-        'flist': 'bp_me/syn/flist.vcs'
+        'flist': 'bp_top/syn/flist.vcs'
     }, {
         'name': 'bp_uce',
         'top': 'bp_uce',
-        'flist': 'bp_me/syn/flist.vcs'
+        'flist': 'bp_top/syn/flist.vcs'
     }, {
         'name': 'bp_unicore',
         'top': 'bp_unicore',


### PR DESCRIPTION
This diff fixes the file lists for some of the black-parrot tests. The other file lists has some problems, and the bp_top file list contains all necessary files for all potential tops so it seems easiest to just use that for all tests.
1. The bp_me file list contains a reference to a nonexistent include directory.
2. The bp_fe and bp_be lists didn't include all of the modules needed to elaborate the core.
3. Some of the tests, such as bp_lce, didn't even include the bp_lce module/file in their test list! Using the bp_top list means that we're actually testing the top modules we think we are.